### PR TITLE
Add support for writing .trc files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,14 @@ uuid = "de436766-0b2a-5f82-bc5b-1ccc5f599b83"
 authors = ["Allen Hill <allenofthehills@gmail.com>"]
 version = "0.5.2"
 
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+VaxData = "a6f58a78-e649-57e2-81bc-1d865c7b74f7"
+
 [compat]
 julia = "1"
-
-[deps]
-VaxData = "a6f58a78-e649-57e2-81bc-1d865c7b74f7"
+VaxData = "0.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -4,7 +4,8 @@ using VaxData
 
 @enum Endian LE=1 BE=2
 
-export readc3d
+export readc3d,
+       writetrc
 
 export C3DFile
 
@@ -21,6 +22,8 @@ struct C3DFile
     residual::Dict{String, Array{Union{Missing, Float32},1}}
     analog::Dict{String, Array{Float32,1}}
 end
+
+include("util.jl")
 
 function C3DFile(name::String, header::Header, groups::Dict{Symbol,Group},
                  point::AbstractArray, residuals::AbstractArray, analog::AbstractArray;

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,127 @@
+using DelimitedFiles, Printf
+
+"""
+    writetrc(filename, f; <keyword arguments>)
+
+Write the C3DFile `f` to a .trc format at `filename`.
+
+# Keyword arguments
+- `delim::Char='\t'`: The text delimiter to use
+- `strip_prefixes::Bool=true`: Strip marker label prefixes if they exist
+- `subject::String=""`: The subject (among multiple subjects) in the C3DFile to write
+- `prefixes::Vector{String}=[subject]`: Marker label prefixes to strip if
+  `strip_prefixes == true`
+- `remove_unlabeled_markers::Bool=true`: Remove markers with empty labels, labels
+  matching r"(\*\d+|M\d\d\d)"
+- `lab_orientation::Matrix=Matrix(I, (3,3))`: Rotation to apply to markers before writing
+- `precision::Int=6`: Number of decimal places to print
+- `virtual_markers::Dict{String,Matrix}`: (Optional) Virtual markers (calculated with markers
+  from `f`) to write to the .trc file
+"""
+function writetrc(filename::String, f::C3DFile; delim::Char='\t', strip_prefixes::Bool=true,
+                  subject::String="", prefixes::Vector{String}=[subject], precision::Int=6,
+                  remove_unlabeled_markers::Bool=true, lab_orientation::Matrix=Matrix(I, (3,3)),
+                  virtual_markers::Dict{String,Matrix}=Dict{String,Matrix{Float32}}()) where T
+    if subject !== ""
+        if haskey(f.groups, :SUBJECTS)
+            any(subject == f.groups[:SUBJECTS].NAMES) || throw(ArgumentError("subject $subject does not exist in $f.groups[:SUBJECTS]"))
+        elseif strip_prefixes && prefixes == [subject]
+            @warn "subject $subject does not exist in $f.groups[:SUBJECTS] and may not be the correct prefix"
+        end
+    end
+
+    io = IOBuffer()
+    len = (f.groups[:POINT].FRAMES == typemax(UInt16)) ?
+        f.groups[:POINT].LONG_FRAMES : f.groups[:POINT].FRAMES
+    period = inv(Float64(f.groups[:POINT].RATE))
+
+    mkrnames = copy(f.groups[:POINT].LABELS)
+    if subject !== ""
+        mkrnames = filter(x -> startswith(x, subject), mkrnames)
+    end
+
+    if strip_prefixes
+        if haskey(f.groups, :SUBJECTS) && f.groups[:SUBJECTS].USES_PREFIXES == 1
+            if subject !== ""
+                subi = findfirst(==(subject), f.groups[:SUBJECTS].NAMES)
+                r = Regex("("*f.groups[:SUBJECTS].LABEL_PREFIXES[subi]*")(?<label>\\w*)")
+                mkrnames_stripped = replace.(mkrnames, r => s"\g<label>")
+            else
+                r = Regex("("*join([f.groups[:SUBJECTS].LABEL_PREFIXES; prefixes], '|')*
+                          ")(?<label>\\w*)")
+                mkrnames_stripped = replace.(mkrnames, r => s"\g<label>")
+            end
+        elseif subject !== "" || prefixes !== [""]
+            if any(subject == prefixes)
+                r = Regex("("*join(prefixes, '|')*
+                          ")(?<label>\\w*)")
+            else
+                r = Regex("("*join([subject; prefixes], '|')*
+                          ")(?<label>\\w*)")
+            end
+            mkrnames_stripped = replace.(mkrnames, r => s"\g<label>")
+        else
+            mkrnames_stripped = mkrnames
+        end
+    else
+        mkrnames_stripped = mkrnames
+    end
+
+    if remove_unlabeled_markers
+        ids = findall(x -> isempty(x) || match(r"(\*\d+|M\d\d\d)", x) !== nothing, mkrnames)
+        ids_strip = findall(x -> isempty(x) || match(r"(\*\d+|M\d\d\d)", x) !== nothing, mkrnames_stripped)
+        @assert ids == ids_strip
+        deleteat!(mkrnames, ids)
+        deleteat!(mkrnames_stripped, ids)
+    end
+
+    # Header
+    line1 = ["PathFileType", "4", "(X/Y/Z)", basename(filename)*'\n']
+    line2 = ["DataRate", "CameraRate", "NumFrames", "NumMarkers", "Units", "OrigDataRate",
+             "OrigDataStartFrame", "OrigNumFrames\n"]
+    join(io, line1, delim)
+    join(io, line2, delim)
+    print(io, f.groups[:POINT].RATE, delim)
+    print(io, f.groups[:POINT].RATE, delim)
+    print(io, len, delim)
+    print(io, length(mkrnames) + length(virtual_markers), delim)
+    print(io, f.groups[:POINT].UNITS, delim)
+    print(io, f.groups[:POINT].RATE, delim)
+    print(io, 1, delim)
+    print(io, len, delim, '\n')
+
+    # Header line
+    write(io, string("Frame#", delim, "Time", delim))
+    join(io, mkrnames_stripped, delim^3)
+    if !isempty(virtual_markers)
+        extra_mkrnames = keys(virtual_markers)
+        join(io, extra_mkrnames, delim^3)
+    end
+    println(io)
+
+    # Coordinate line
+    write(io, delim^2)
+    join(io, (string('X', n, delim, 'Y', n, delim, 'Z', n)
+              for n in 1:(length(mkrnames)+length(virtual_markers))), delim)
+    write(io, '\n'^2)
+
+    # Core data block
+    data = reduce(hcat, (f.point[mkrname]*lab_orientation for mkrname in mkrnames);
+                  init=collect(range(0; step=period, length=len))::Any)
+    if !isempty(virtual_markers)
+        data = reduce(hcat, (virtual_markers[mkrname]*lab_orientation for mkrname in extra_mkrnames);
+                      init=data)
+    end
+    data .= round.(data; digits=precision)
+    data = Any[ 1:len data ]
+    replace!(data, missing=>"")
+    replace!(data, NaN=>"")
+    writedlm(io, data, delim)
+
+    open(filename, "w") do fio
+        write(fio, io)
+    end
+
+    return filename
+end
+

--- a/src/util.jl
+++ b/src/util.jl
@@ -38,6 +38,7 @@ function writetrc(filename::String, f::C3DFile; delim::Char='\t', strip_prefixes
     mkrnames = copy(f.groups[:POINT].LABELS)
     if subject !== ""
         mkrnames = filter(x -> startswith(x, subject), mkrnames)
+        isempty(mkrnames) && @warn "no markers matched subject $subject"
     end
 
     if strip_prefixes

--- a/src/util.jl
+++ b/src/util.jl
@@ -6,13 +6,13 @@ using DelimitedFiles, Printf
 Write the C3DFile `f` to a .trc format at `filename`.
 
 # Keyword arguments
-- `delim::Char='\t'`: The text delimiter to use
+- `delim::Char='\\t'`: The text delimiter to use
 - `strip_prefixes::Bool=true`: Strip marker label prefixes if they exist
 - `subject::String=""`: The subject (among multiple subjects) in the C3DFile to write
 - `prefixes::Vector{String}=[subject]`: Marker label prefixes to strip if
   `strip_prefixes == true`
 - `remove_unlabeled_markers::Bool=true`: Remove markers with empty labels, labels
-  matching `r"(\*\d+|M\d\d\d)"`
+  matching `r"(\\*\\d+|M\\d\\d\\d)"`
 - `lab_orientation::Matrix=Matrix(I, (3,3))`: Rotation to apply to markers before writing
 - `precision::Int=6`: Number of decimal places to print
 - `virtual_markers::Dict{String,Matrix}`: (Optional) Virtual markers (calculated with markers

--- a/src/util.jl
+++ b/src/util.jl
@@ -12,7 +12,7 @@ Write the C3DFile `f` to a .trc format at `filename`.
 - `prefixes::Vector{String}=[subject]`: Marker label prefixes to strip if
   `strip_prefixes == true`
 - `remove_unlabeled_markers::Bool=true`: Remove markers with empty labels, labels
-  matching r"(\*\d+|M\d\d\d)"
+  matching `r"(\*\d+|M\d\d\d)"`
 - `lab_orientation::Matrix=Matrix(I, (3,3))`: Rotation to apply to markers before writing
 - `precision::Int=6`: Number of decimal places to print
 - `virtual_markers::Dict{String,Matrix}`: (Optional) Virtual markers (calculated with markers


### PR DESCRIPTION
`writetrc(filename, f; <keyword arguments>)`

Write the C3DFile `f` to a .trc format at `filename`.

# Keyword arguments
- `delim::Char='\t'`: The text delimiter to use
- `strip_prefixes::Bool=true`: Strip marker label prefixes if they exist
- `subject::String=""`: The subject (among multiple subjects) in the C3DFile to write
- `prefixes::Vector{String}=[subject]`: Marker label prefixes to strip if
  `strip_prefixes == true`
- `remove_unlabeled_markers::Bool=true`: Remove markers with empty labels, labels
  matching `r"(\*\d+|M\d\d\d)"`
- `lab_orientation::Matrix=Matrix(I, (3,3))`: Rotation to apply to markers before writing
- `precision::Int=6`: Number of decimal places to print
- `virtual_markers::Dict{String,Matrix}`: (Optional) Virtual markers (calculated with markers
  from `f`) to write to the .trc file