### PR TITLE
Replace `getproperty` parameter data access with typed `getindex` to improve inference

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ VaxData = "a6f58a78-e649-57e2-81bc-1d865c7b74f7"
 
 [compat]
 julia = "1"
-VaxData = "0.5"
+VaxData = "0.5,0.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "C3D"
 uuid = "de436766-0b2a-5f82-bc5b-1ccc5f599b83"
 authors = ["Allen Hill <allenofthehills@gmail.com>"]
-version = "0.6.3"
+version = "0.7.0"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
@@ -9,7 +9,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 VaxData = "a6f58a78-e649-57e2-81bc-1d865c7b74f7"
 
 [compat]
-julia = "1"
+julia = "1.6"
 VaxData = "0.5,0.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -100,11 +100,14 @@ Symbol[:DESCRIPTIONS, :RATE, :DATA_START, :FRAMES, :USED, :UNITS, :Y_SCREEN, :LA
 
 There are two ways to access a specific parameter. The first (and most convenient) directly references the data contained in the parameter.
 
+**BREAKING**: Previous versions (<v0.7.0) of C3D.jl used a different syntax for this:
+`pc_real.groups[:POINT].USED`. See PR#9 for the reasons for the change.
+
 ```julia
-julia> pc_real.groups[:POINT].USED
+julia> pc_real.groups[:POINT][:USED]
 26
 
-julia> pc_real.groups[:POINT].LABELS
+julia> pc_real.groups[:POINT][:LABELS]
 48-element Array{String,1}:
  "RFT1"
  "RFT2"

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -79,18 +79,18 @@ function calcresiduals(x::AbstractVector, scale)
     residuals = (reinterpret.(UInt32, x) .>> 16) .& 0xff .* scale
 end
 
-function readdata(f::IOStream, groups::Dict{Symbol,Group}, FEND::Endian, FType::Type{T}) where T <: Union{Float32,VaxFloatF}
-    seek(f, (groups[:POINT].DATA_START-1)*512)
+function readdata(io::IOStream, groups::Dict{Symbol,Group}, FEND::Endian, FType::Type{T}) where T <: Union{Float32,VaxFloatF}
+    seek(io, (groups[:POINT].DATA_START-1)*512)
 
     format = groups[:POINT].SCALE > 0 ? Int16 : FType
 
     # Read data in a transposed structure for better read/write speeds due to Julia being
     # column-order arrays
-    numframes = convert(Int, groups[:POINT].FRAMES)
+    numframes::Int = groups[:POINT].FRAMES
     if numframes == typemax(UInt16) && haskey(groups, :TRIAL) && haskey(groups[:TRIAL].params, :ACTUAL_END_FIELD)
         numframes = convert(Int, reinterpret(Int32, groups[:TRIAL].ACTUAL_END_FIELD)[1])
     end
-    nummarkers = convert(Int, groups[:POINT].USED)
+    nummarkers::Int = groups[:POINT].USED
     hasmarkers = !iszero(nummarkers)
     if hasmarkers
         point = Array{Float32,2}(undef, nummarkers*3, numframes)
@@ -100,7 +100,7 @@ function readdata(f::IOStream, groups::Dict{Symbol,Group}, FEND::Endian, FType::
         pointidxs = filter(x -> x % 4 != 0, 1:nb)
         residxs = filter(x -> x % 4 == 0, 1:nb)
 
-        pointtmp = Array{format}(undef, nb)
+        pointtmp = Vector{format}(undef, nb)
         pointview = view(pointtmp, pointidxs)
         resview = view(pointtmp, residxs)
     else
@@ -108,43 +108,48 @@ function readdata(f::IOStream, groups::Dict{Symbol,Group}, FEND::Endian, FType::
         residuals = Array{Float32,2}(undef, 0,0)
     end
 
-    numchannels = convert(Int, groups[:ANALOG].USED)
+    numchannels::Int = groups[:ANALOG].USED
     haschannels = !iszero(numchannels)
     if haschannels
         # Analog Samples Per Frame => ASPF
-        aspf = convert(Int, groups[:ANALOG].RATE/groups[:POINT].RATE)
+        aspf::Int = groups[:ANALOG].RATE/groups[:POINT].RATE
         analog = Array{Float32,2}(undef, numchannels, aspf*numframes)
 
-        analogtmp = Array{format}(undef, (numchannels,aspf))
+        analogtmp = Matrix{format}(undef, (numchannels,aspf))
     else
         analog = Array{Float32,2}(undef, 0,0)
     end
 
     @inbounds for i in 1:numframes
         if hasmarkers
-            saferead!(f, pointtmp, FEND)
-            point[:,i] = convert.(Float32, pointview) # Convert from `format` (eg Int16 or FType)
-            residuals[:,i] = convert.(Float32, resview)
+            saferead!(io, pointtmp, FEND)
+            point[:,i] = pointview
+            residuals[:,i] = resview
         end
         if haschannels
-            saferead!(f, analogtmp, FEND)
-            analog[:,((i-1)*aspf+1):(i*aspf)] = convert.(Float32, analogtmp)
+            saferead!(io, analogtmp, FEND)
+            analog[:,((i-1)*aspf+1):(i*aspf)] = analogtmp
         end
     end
 
     if hasmarkers && format == Int16
         # Multiply or divide by [:point][:scale]
-        point .*= abs(groups[:POINT].SCALE)
+        POINT_SCALE::Float32 = groups[:POINT].SCALE
+        point .*= abs(POINT_SCALE)
     end
 
     if haschannels
         if numchannels == 1
-            analog[:] = (analog .- groups[:ANALOG].OFFSET) .*
-                        (groups[:ANALOG].GEN_SCALE * groups[:ANALOG].SCALE)
+            ANALOG_OFFSET = groups[:ANALOG].OFFSET::Float32
+            SCALE = (groups[:ANALOG].GEN_SCALE * groups[:ANALOG].SCALE)::Float32
+            analog .= (analog .- ANALOG_OFFSET) .* SCALE
         else
-            analog[:] = (analog .- groups[:ANALOG].OFFSET[1:numchannels]) .*
-                        groups[:ANALOG].GEN_SCALE .*
-                        groups[:ANALOG].SCALE[1:numchannels]
+            VECANALOG_OFFSET = convert(Vector{Float32},
+                groups[:ANALOG].OFFSET[1:numchannels])::Vector{Float32}
+            VECSCALE = convert(Vector{Float32}, groups[:ANALOG].GEN_SCALE .*
+                               groups[:ANALOG].SCALE[1:numchannels])::Vector{Float32}
+
+            analog .= (analog .- VECANALOG_OFFSET) .* VECSCALE
         end
     end
 
@@ -184,11 +189,11 @@ function saferead(io::IOStream, ::Type{VaxFloatF}, FEND::Endian)::Float32
     end
 end
 
-function saferead(io::IOStream, ::Type{VaxFloatF}, FEND::Endian, dims)::Array{Float32}
+function saferead(io::IOStream, ::Type{VaxFloatF}, FEND::Endian, dims::NTuple{N,Int})::Array{Float32,N} where N
     if FEND == LE
-        return convert.(Float32, ltoh.(read!(io, Array{VaxFloatF}(undef, dims))))
+        return convert(Array{Float32,N}, ltoh.(read!(io, Array{VaxFloatF}(undef, dims))))
     else
-        return convert.(Float32, ntoh.(read!(io, Array{VaxFloatF}(undef, dims))))
+        return convert(Array{Float32,N}, ntoh.(read!(io, Array{VaxFloatF}(undef, dims))))
     end
 end
 
@@ -208,12 +213,12 @@ function readc3d(fn::AbstractString; paramsonly=false, validate=true,
         error("File ", fn, " cannot be found")
     end
 
-    f = open(fn, "r")
+    io = open(fn, "r")
 
-    groups, header, FEND, FType = _readparams(fn, f)
+    groups, header, FEND, FType = _readparams(fn, io)
 
     if validate
-        validatec3d(header, groups, complete=false)
+        validatec3d(header, groups)
     end
 
     if paramsonly
@@ -221,32 +226,32 @@ function readc3d(fn::AbstractString; paramsonly=false, validate=true,
         residual = Dict{String,Array{Union{Missing, Float32},1}}()
         analog = Dict{String,Array{Float32,1}}()
     else
-        (point, residual, analog) = readdata(f, groups, FEND, FType)
+        (point, residual, analog) = readdata(io, groups, FEND, FType)
     end
 
-    res = C3DFile(fn, header, groups, point, residual, analog; missingpoints=missingpoints)
+    close(io)
 
-    close(f)
+    res = C3DFile(fn, header, groups, point, residual, analog; missingpoints=missingpoints)
 
     return res
 end
 
-function _readparams(fn::String, f::IOStream)
-    params_ptr = read(f, UInt8)
+function _readparams(fn::String, io::IOStream)
+    params_ptr = read(io, UInt8)
 
-    if read(f, UInt8) != 0x50
+    if read(io, UInt8) != 0x50
         error("File ", fn, " is not a valid C3D file")
     end
 
     # Jump to parameters block
-    seek(f, (params_ptr - 1) * 512)
+    seek(io, (params_ptr - 1) * 512)
 
     # Skip 2 reserved bytes
     # TODO: store bytes for saving modified files
-    skip(f, 2)
+    skip(io, 2)
 
-    paramblocks = read(f, UInt8)
-    proctype = read(f, Int8) - 83
+    paramblocks = read(io, UInt8)
+    proctype = read(io, Int8) - 83
 
     FType = Float32
 
@@ -265,89 +270,89 @@ function _readparams(fn::String, f::IOStream)
         error("Malformed processor type. Expected 1, 2, or 3. Found ", proctype)
     end
 
-    mark(f)
-    header = readheader(f, FEND, FType)
-    reset(f)
-    unmark(f)
+    mark(io)
+    header = readheader(io, FEND, FType)
+    reset(io)
+    unmark(io)
 
     gs = Array{Group,1}()
-    ps = Array{AbstractParameter,1}()
+    ps = Array{Parameter,1}()
     moreparams = true
     fail = 0
     np = 0
 
-    skip(f, 1)
-    if read(f, Int8) < 0
+    skip(io, 1)
+    if read(io, Int8) < 0
         # Group
-        skip(f, -2)
-        push!(gs, readgroup(f, FEND, FType))
+        skip(io, -2)
+        push!(gs, readgroup(io, FEND, FType))
         np = gs[end].pos + gs[end].np + abs(gs[end].nl) + 2
         moreparams = gs[end].np != 0 ? true : false
     else
         # Parameter
-        skip(f, -2)
-        push!(ps, readparam(f, FEND, FType))
-        np = ps[end].pos + ps[end].np + abs(ps[end].nl) + 2
-        moreparams = ps[end].np != 0 ? true : false
+        skip(io, -2)
+        push!(ps, readparam(io, FEND, FType))
+        np = ps[end].pos::Int + ps[end].np::Int16 + abs(ps[end].nl::Int8) + 2
+        moreparams = ps[end].np::Int16 != 0 ? true : false
     end
 
     while moreparams
         # Mark current position in file in case the pointer is incorrect
-        mark(f)
-        if fail === 0 && np != position(f)
-                @debug "Pointer mismatch at position $(position(f)) where pointer was $np"
-                seek(f, np)
+        mark(io)
+        if fail === 0 && np != position(io)
+                # @debug "Pointer mismatch at position $(position(io)) where pointer was $np"
+                seek(io, np)
         elseif fail > 1 # this is the second failed attempt
-            @debug "Second failed parameter read attempt from $(position(f))"
+            # @debug "Second failed parameter read attempt from $(position(io))"
             break
         end
 
         # Read the next two bytes to get the gid
-        skip(f, 1)
-        local gid = read(f, Int8)
+        skip(io, 1)
+        local gid = read(io, Int8)
         if gid < 0 # Group
             # Reset to the beginning of the group
-            skip(f, -2)
+            skip(io, -2)
             try
-                push!(gs, readgroup(f, FEND, FType))
+                push!(gs, readgroup(io, FEND, FType))
                 np = gs[end].pos + gs[end].np + abs(gs[end].nl) + 2
                 moreparams = gs[end].np != 0 ? true : false # break if the pointer is 0 (ie the parameters are finished)
                 fail = 0 # reset fail counter following a successful read
             catch e
                 # Last readgroup failed, possibly due to a bad pointer. Reset to the ending
                 # location of the last successfully read parameter and try again. Count the failure.
-                reset(f)
-                @debug "Read group failed, last parameter ended at $(position(f)), pointer at $np" fail
+                reset(io)
+                # @debug "Read group failed, last parameter ended at $(position(io)), pointer at $np" fail
                 fail += 1
             finally
-                unmark(f) # Unmark the file regardless
+                unmark(io) # Unmark the file regardless
             end
         elseif gid > 0 # Parameter
             # Reset to the beginning of the parameter
-            skip(f, -2)
+            skip(io, -2)
             try
-                push!(ps, readparam(f, FEND, FType))
-                np = ps[end].pos + ps[end].np + abs(ps[end].nl) + 2
-                moreparams = ps[end].np != 0 ? true : false
+                push!(ps, readparam(io, FEND, FType))
+                np = ps[end].pos::Int + ps[end].np::Int16 + abs(ps[end].nl::Int8) + 2
+                moreparams = ps[end].np::Int16 != 0 ? true : false
                 fail = 0
             catch e
-                reset(f)
-                @debug "Read group failed, last parameter ended at $(position(f)), pointer at $np" fail
+                reset(io)
+                # @debug "Read group failed, last parameter ended at $(position(io)), pointer at $np" fail
                 fail += 1
             finally
-                unmark(f)
+                unmark(io)
             end
         else # Last parameter pointer is incorrect (assumption)
             # The group ID should never be zero, if it is, the most likely explanation is
             # that the pointer is incorrect (eg the pointer was not fixed when the previously
             # last parameter was deleted or moved)
-            @debug "Bad last position. Assuming parameter section is finished."
+            # @debug "Bad last position. Assuming parameter section is finished."
             break
         end
     end
 
     groups = Dict{Symbol,Group}()
-    gids = Dict{Int,Symbol}()
+    gids = Dict{Int8,Symbol}()
 
     for group in gs
         groups[group.symname] = group

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -9,16 +9,35 @@ struct Group
     np::Int16 # Pointer in bytes to the start of next group/parameter (officially supposed to be signed)
     dl::UInt8 # Number of characters in group description (nominally should be between 1 and 127)
     desc::String # Character set should be A-Z, 0-9, and _ (lowercase is ok)
-    params::Dict{Symbol,AbstractParameter}
+    params::Dict{Symbol,Parameter}
 end
 
 function Base.getproperty(g::Group, name::Symbol)
-    if name ∈ fieldnames(typeof(g))
-        return getfield(g, name)
+    if name === :pos
+        return getfield(g, :pos)::Int
+    elseif name === :nl
+        return getfield(g, :nl)::Int8
+    elseif name === :isLocked
+        return getfield(g, :isLocked)::Bool
+    elseif name === :gid
+        return getfield(g, :gid)::Int8
+    elseif name === :name
+        return getfield(g, :name)::String
+    elseif name === :symname
+        return getfield(g, :symname)::Symbol
+    elseif name === :np
+        return getfield(g, :np)::Int16
+    elseif name === :dl
+        return getfield(g, :dl)::UInt8
+    elseif name === :desc
+        return getfield(g, :desc)::String
+    elseif name === :params
+        return getfield(g, :params)::Dict{Symbol,Parameter}
     else
-        return getfield(g, :params)[name].data
+        return getfield(g, :params)[name].payload.data
     end
 end
+
 Base.show(io::IO, g::Group) = show(io, keys(g.params))
 
 function readgroup(f::IOStream, FEND::Endian, FType::Type{T}) where T <: Union{Float32,VaxFloatF}
@@ -32,15 +51,15 @@ function readgroup(f::IOStream, FEND::Endian, FType::Type{T}) where T <: Union{F
     @assert any(!iscntrl, name)
     symname = Symbol(replace(strip(name), r"[^a-zA-Z0-9_]" => '_'))
 
-    if occursin(r"[^a-zA-Z0-9_ ]", name)
-        @debug "Group $name at $pos has unofficially supported characters.
-            Unexpected results may occur"
-    end
+    # if occursin(r"[^a-zA-Z0-9_ ]", name)
+    #     @debug "Group $name at $pos has unofficially supported characters.
+    #         Unexpected results may occur"
+    # end
 
     np = saferead(f, Int16, FEND)
     dl = read(f, UInt8)
     desc = transcode(String, read(f, dl))
 
-    return Group(pos, nl, isLocked, gid, name, symname, np, dl, desc, Dict{Symbol,AbstractParameter}())
+    return Group(pos, nl, isLocked, gid, name, symname, np, dl, desc, Dict{Symbol,Parameter}())
 end
 

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -12,30 +12,17 @@ struct Group
     params::Dict{Symbol,Parameter}
 end
 
-function Base.getproperty(g::Group, name::Symbol)
-    if name === :pos
-        return getfield(g, :pos)::Int
-    elseif name === :nl
-        return getfield(g, :nl)::Int8
-    elseif name === :isLocked
-        return getfield(g, :isLocked)::Bool
-    elseif name === :gid
-        return getfield(g, :gid)::Int8
-    elseif name === :name
-        return getfield(g, :name)::String
-    elseif name === :symname
-        return getfield(g, :symname)::Symbol
-    elseif name === :np
-        return getfield(g, :np)::Int16
-    elseif name === :dl
-        return getfield(g, :dl)::UInt8
-    elseif name === :desc
-        return getfield(g, :desc)::String
-    elseif name === :params
-        return getfield(g, :params)::Dict{Symbol,Parameter}
-    else
-        return getfield(g, :params)[name].payload.data
-    end
+function typedindex(g::Group, ::Type{T}, k) where T
+    r::T = getindex(g.params, k).payload.data
+    return r
+end
+
+function Base.getindex(g::Group, ::Type{T}, k::Symbol) where T
+    return typedindex(g, T, k)
+end
+
+function Base.getindex(g::Group, k::Symbol)
+    return getindex(g.params, k).payload.data
 end
 
 Base.show(io::IO, g::Group) = show(io, keys(g.params))

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -59,8 +59,8 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group})
         end
     end
 
-    POINT_USED::Int = groups[:POINT].USED
-    ANALOG_USED::Int = groups[:ANALOG].USED
+    POINT_USED = groups[:POINT][Int, :USED]
+    ANALOG_USED = groups[:ANALOG][Int, :USED]
     if POINT_USED != 0 # There are markers
         # If there are markers, the additional set of required parameters is ratescale
         if !(ratescale ⊆ pointkeys)
@@ -95,7 +95,7 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group})
             groups[:POINT].params[:LABELS] = Parameter{StringParameter}(groups[:POINT].params[:LABELS])
         end
 
-        POINT_LABELS = groups[:POINT].params[:LABELS].payload.data::Vector{String}
+        POINT_LABELS = groups[:POINT][Vector{String}, :LABELS]
         # Valid labels are required for each marker by the C3DFile constructor
         if any(isempty, POINT_LABELS) ||
            length(POINT_LABELS) < POINT_USED # Some markers don't have labels
@@ -103,8 +103,7 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group})
             while length(POINT_LABELS) < POINT_USED
                 # Check for the existence of a runoff labels group
                 if haskey(groups[:POINT].params, Symbol("LABEL",i))
-                    append!(POINT_LABELS,
-                            groups[:POINT].params[Symbol("LABEL",i)].payload.data)
+                    append!(POINT_LABELS, groups[:POINT][Vector{String}, Symbol("LABEL",i)])
                     i += 1
                 else
                     push!(POINT_LABELS, "")
@@ -183,25 +182,25 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group})
         end
 
         # Pad scale and offset if shorter than :USED
-        l::Int = length(groups[:ANALOG].SCALE)
+        l = length(groups[:ANALOG][Vector{Float32}, :SCALE])
         if l < ANALOG_USED
-            append!(groups[:ANALOG].params[:SCALE].payload.data,
-                    fill(Float32(1.0), ANALOG_USED - l))
+            append!(groups[:ANALOG][Vector{Float32}, :SCALE],
+                    fill(one(Float32), ANALOG_USED - l))
         end
 
-        l = length(groups[:ANALOG].OFFSET)
+        l = length(groups[:ANALOG][Vector{Int16}, :OFFSET])
         if l < ANALOG_USED
-            append!(groups[:ANALOG].params[:OFFSET].payload.data,
-                    fill(Float32(1.0), ANALOG_USED - l))
+            append!(groups[:ANALOG][Vector{Int16}, :OFFSET],
+                    fill(one(Float32), ANALOG_USED - l))
         end
 
-        ANALOG_LABELS::Vector{String} = groups[:ANALOG].params[:LABELS].payload.data
+        ANALOG_LABELS = groups[:ANALOG][Vector{String}, :LABELS]
         if any(isempty, ANALOG_LABELS) ||
            length(ANALOG_LABELS) < ANALOG_USED # Some markers don't have labels
             i = 2
             while length(ANALOG_LABELS) < ANALOG_USED
                 if haskey(groups[:ANALOG].params, Symbol("LABEL",i)) # Check for the existence of a runoff labels group
-                    append!(ANALOG_LABELS, groups[:ANALOG].params[Symbol("LABEL",i)].payload.data::Vector{String})
+                    append!(ANALOG_LABELS, groups[:ANALOG][Vector{String}, Symbol("LABEL",i)])
                     i += 1
                 else
                     push!(ANALOG_LABELS, "")

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -19,12 +19,16 @@ const pointsigncheck = ((:POINT, :USED),
 # const analogsigncheck = (:ANALOG, :USED)
 # const fpsigncheck = (:FORCE_PLATFORM, :ZERO)
 
-function validatec3d(header::Header, groups::Dict{Symbol,Group}; complete=false)
-    # The following if-else ensures the minimum set of information needed to succesfully read a C3DFile
+function validatec3d(header::Header, groups::Dict{Symbol,Group})
+    # The following if-else ensures the minimum set of information needed to succesfully
+    # read a C3DFile
     if !(rgroups ⊆ keys(groups))
         if !haskey(groups, :ANALOG)
-            groups[:ANALOG] = Group(0, Int8(6), false, Int8(0), "ANALOG", :ANALOG, Int16(0), UInt8(22), "Analog data parameters", Dict{Symbol,AbstractParameter}())
-            groups[:ANALOG].params[:USED] = ScalarParameter(0, Int8(5), false, Int8(0), "USED", :USED, Int16(0), zero(Int16), UInt8(30), "Number of analog channels used")
+            groups[:ANALOG] = Group(0, Int8(6), false, Int8(0), "ANALOG", :ANALOG, Int16(0),
+                UInt8(22), "Analog data parameters", Dict{Symbol,Parameter}())
+            groups[:ANALOG].params[:USED] = Parameter(0, Int8(5), false, Int8(0), "USED",
+                :USED, Int16(0), UInt8(30), "Number of analog channels used",
+                ScalarParameter(zero(Int16)))
         else
             d = setdiff(rgroups, keys(groups))
             msg = "Required group(s)"
@@ -50,14 +54,17 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group}; complete=false)
 
     # Fix the sign for any point parameters that are likely to need it
     for (group, param) in pointsigncheck
-        if any(signbit.(groups[group].params[param].data))
+        if any(signbit, groups[group].params[param].payload.data)
             groups[group].params[param] = unsigned(groups[group].params[param])
         end
     end
 
-    if groups[:POINT].USED != 0 # There are markers
-        if !(ratescale ⊆ pointkeys) # If there are markers, the additional set of required parameters is ratescale
-            if !(:RATE ∈ pointkeys) && groups[:ANALOG].USED == 0
+    POINT_USED::Int = groups[:POINT].USED
+    ANALOG_USED::Int = groups[:ANALOG].USED
+    if POINT_USED != 0 # There are markers
+        # If there are markers, the additional set of required parameters is ratescale
+        if !(ratescale ⊆ pointkeys)
+            if !(:RATE ∈ pointkeys) && ANALOG_USED == 0
                 # If there is no analog data, POINT:RATE isn't technically required
             else
                 d = setdiff(rpoint, pointkeys)
@@ -71,54 +78,60 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group}; complete=false)
 
         if !(descriptives ⊆ pointkeys) # Check that the descriptive parameters exist
             if !haskey(groups[:POINT].params, :LABELS)
-                # While the C3D file can technically be read in the absence of a LABELS parameter,
-                # this implementation requires LABELS (for indexing)
+                # While the C3D file can technically be read in the absence of a LABELS
+                # parameter, this implementation requires LABELS (for indexing)
                 @debug ":POINT is missing parameter :LABELS"
-                labels = [ "M"*string(i, pad=3) for i in 1:groups[:POINT].USED ]
-                groups[:POINT].params[:LABELS] =
-                      StringParameter(0, Int8(0), false, abs(groups[:POINT].gid), "LABELS", :LABELS, Int16(0), labels, UInt8(13), "Marker labels")
+                labels = [ "M"*string(i, pad=3) for i in 1:POINT_USED ]
+                groups[:POINT].params[:LABELS] = Parameter(0, Int8(0), false,
+                    abs(groups[:POINT].gid), "LABELS", :LABELS, Int16(0), UInt8(13),
+                    "Marker labels", StringParameter(labels))
             elseif !haskey(groups[:POINT].params, :DESCRIPTIONS)
                 @debug ":POINT is missing parameter :DESCRIPTIONS"
             elseif !haskey(groups[:POINT].params, :UNITS)
                 @debug ":POINT is missing parameter :UNITS"
             end
-        elseif groups[:POINT].params[:LABELS] isa ScalarParameter # ie There is only one used marker (or the others are unlabeled)
-            groups[:POINT].params[:LABELS] = StringParameter(groups[:POINT].params[:LABELS])
+        elseif groups[:POINT].params[:LABELS] isa Parameter{ScalarParameter}
+            # ie There is only one used marker (or the others are unlabeled)
+            groups[:POINT].params[:LABELS] = Parameter{StringParameter}(groups[:POINT].params[:LABELS])
         end
 
+        POINT_LABELS = groups[:POINT].params[:LABELS].payload.data::Vector{String}
         # Valid labels are required for each marker by the C3DFile constructor
-        if any(isempty.(groups[:POINT].LABELS)) ||
-           length(groups[:POINT].LABELS) < groups[:POINT].USED # Some markers don't have labels
+        if any(isempty, POINT_LABELS) ||
+           length(POINT_LABELS) < POINT_USED # Some markers don't have labels
             i = 2
-            while length(groups[:POINT].LABELS) < groups[:POINT].USED
-                if haskey(groups[:POINT].params, Symbol("LABEL",i)) # Check for the existence of a runoff labels group
-                    append!(groups[:POINT].LABELS, groups[:POINT].params[Symbol("LABEL",i)].data)
+            while length(POINT_LABELS) < POINT_USED
+                # Check for the existence of a runoff labels group
+                if haskey(groups[:POINT].params, Symbol("LABEL",i))
+                    append!(POINT_LABELS,
+                            groups[:POINT].params[Symbol("LABEL",i)].payload.data)
                     i += 1
                 else
-                    push!(groups[:POINT].LABELS, "")
+                    push!(POINT_LABELS, "")
                 end
             end
 
-            idx = findall(isempty, groups[:POINT].LABELS)
+            idx = findall(isempty, POINT_LABELS)
             labels = [ "M"*string(i, pad=3) for i in 1:length(idx) ]
-            groups[:POINT].LABELS[idx] .= labels
+            POINT_LABELS[idx] .= labels
         end
 
-        if length(unique(groups[:POINT].LABELS)) !== length(groups[:POINT].LABELS)
+        if !allunique(POINT_LABELS)
             dups = String[]
-            for i in 1:groups[:POINT].USED
-                if !in(groups[:POINT].LABELS[i], dups)
-                    push!(dups, groups[:POINT].LABELS[i])
+            for i in 1:POINT_USED
+                if !in(POINT_LABELS[i], dups)
+                    push!(dups, POINT_LABELS[i])
                 else
-                    m = match(r"_(?<num>\d+)$", groups[:POINT].LABELS[i])
+                    m = match(r"_(?<num>\d+)$", POINT_LABELS[i])
 
-                    if m == nothing
-                        groups[:POINT].LABELS[i] *= "_2"
-                        push!(dups, groups[:POINT].LABELS[i])
+                    if m === nothing
+                        POINT_LABELS[i] *= "_2"
+                        push!(dups, POINT_LABELS[i])
                     else
-                        newlabel = groups[:POINT].LABELS[i][1:(m.offset - 1)]*string('_',tryparse(Int,m[:num])+1)
-                        groups[:POINT].LABELS[i] = newlabel
-                        push!(dups, groups[:POINT].LABELS[i])
+                        newlabel = POINT_LABELS[i][1:(m.offset - 1)] *
+                            string('_',tryparse(Int,m[:num])+1)
+                        POINT_LABELS[i] = newlabel
+                        push!(dups, POINT_LABELS[i])
                     end
                 end
             end
@@ -132,14 +145,15 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group}; complete=false)
         throw(ErrorException(msg))
     end
 
-    if signbit(groups[:ANALOG].USED)
+    if signbit(ANALOG_USED)
         groups[:ANALOG].params[:USED] = unsigned(groups[:ANALOG].params[:USED])
     end
 
-    if groups[:ANALOG].USED != 0 # There are analog channels
+    if ANALOG_USED != 0 # There are analog channels
 
         @label analogkeychanged
-        if !(ranalog ⊆ analogkeys) # If there are analog channels, the required set of parameters is ranalog
+        # If there are analog channels, the required set of parameters is ranalog
+        if !(ranalog ⊆ analogkeys)
             if :OFFSETS ∈ analogkeys
                 groups[:ANALOG].params[:OFFSET] = groups[:ANALOG].params[:OFFSETS]
                 delete!(groups[:ANALOG].params, :OFFSETS)
@@ -155,9 +169,10 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group}; complete=false)
         elseif !(descriptives ⊆ analogkeys) # Check that the descriptive parameters exist
             if !haskey(groups[:ANALOG].params, :LABELS)
                 @debug ":ANALOG is missing parameter :LABELS"
-                labels = [ "A"*string(i, pad=3) for i in 1:groups[:ANALOG].USED ]
-                groups[:ANALOG].params[:LABELS] =
-                      StringParameter(0, Int8(0), false, abs(groups[:ANALOG].gid), "LABELS", :LABELS, Int16(0), labels, UInt8(14), "Channel labels")
+                labels = [ "A"*string(i, pad=3) for i in 1:ANALOG_USED ]
+                groups[:ANALOG].params[:LABELS] = Parameter{StringParameter}(0, Int8(0),
+                    false, abs(groups[:ANALOG].gid), "LABELS", :LABELS, Int16(0), UInt8(14),
+                    "Channel labels", StringParameter(labels))
             elseif !haskey(groups[:ANALOG].params, :DESCRIPTIONS)
                 @debug ":ANALOG is missing parameter :DESCRIPTIONS"
             elseif !haskey(groups[:ANALOG].params, :UNITS)
@@ -168,54 +183,58 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group}; complete=false)
         end
 
         # Pad scale and offset if shorter than :USED
-        l = length(groups[:ANALOG].SCALE)
-        if l < groups[:ANALOG].USED
-            append!(groups[:ANALOG].params[:SCALE].data, fill(Float32(1.0), groups[:ANALOG].USED - l))
+        l::Int = length(groups[:ANALOG].SCALE)
+        if l < ANALOG_USED
+            append!(groups[:ANALOG].params[:SCALE].payload.data,
+                    fill(Float32(1.0), ANALOG_USED - l))
         end
 
         l = length(groups[:ANALOG].OFFSET)
-        if l < groups[:ANALOG].USED
-            append!(groups[:ANALOG].params[:OFFSET].data, fill(Float32(1.0), groups[:ANALOG].USED - l))
+        if l < ANALOG_USED
+            append!(groups[:ANALOG].params[:OFFSET].payload.data,
+                    fill(Float32(1.0), ANALOG_USED - l))
         end
 
-        if any(isempty.(groups[:ANALOG].LABELS)) ||
-           length(groups[:ANALOG].LABELS) < groups[:ANALOG].USED # Some markers don't have labels
+        ANALOG_LABELS::Vector{String} = groups[:ANALOG].params[:LABELS].payload.data
+        if any(isempty, ANALOG_LABELS) ||
+           length(ANALOG_LABELS) < ANALOG_USED # Some markers don't have labels
             i = 2
-            while length(groups[:ANALOG].LABELS) < groups[:ANALOG].USED
+            while length(ANALOG_LABELS) < ANALOG_USED
                 if haskey(groups[:ANALOG].params, Symbol("LABEL",i)) # Check for the existence of a runoff labels group
-                    append!(groups[:ANALOG].LABELS, groups[:ANALOG].params[Symbol("LABEL",i)].data)
+                    append!(ANALOG_LABELS, groups[:ANALOG].params[Symbol("LABEL",i)].payload.data::Vector{String})
                     i += 1
                 else
-                    push!(groups[:ANALOG].LABELS, "")
+                    push!(ANALOG_LABELS, "")
                 end
             end
 
-            idx = findall(isempty, groups[:ANALOG].LABELS)
+            idx = findall(isempty, ANALOG_LABELS)
             labels = [ "A"*string(i, pad=3) for i in 1:length(idx) ]
-            groups[:ANALOG].LABELS[idx] .= labels
+            ANALOG_LABELS[idx] .= labels
         end
 
-        if length(unique(groups[:ANALOG].LABELS)) !== length(groups[:ANALOG].LABELS)
+        if !allunique(ANALOG_LABELS)
             dups = String[]
-            for i in 1:groups[:ANALOG].USED
-                if !in(groups[:ANALOG].LABELS[i], dups)
-                    push!(dups, groups[:ANALOG].LABELS[i])
+            for i in 1:ANALOG_USED
+                if !in(ANALOG_LABELS[i], dups)
+                    push!(dups, ANALOG_LABELS[i])
                 else
-                    m = match(r"_(?<num>\d+)$", groups[:ANALOG].LABELS[i])
+                    m = match(r"_(?<num>\d+)$", ANALOG_LABELS[i])
 
-                    if m == nothing
-                        groups[:ANALOG].LABELS[i] *= "_2"
-                        push!(dups, groups[:ANALOG].LABELS[i])
+                    if m === nothing
+                        ANALOG_LABELS[i] *= "_2"
+                        push!(dups, ANALOG_LABELS[i])
                     else
-                        newlabel = groups[:ANALOG].LABELS[i][1:(m.offset - 1)]*string('_',tryparse(Int,m[:num])+1)
-                        groups[:ANALOG].LABELS[i] = newlabel
-                        push!(dups, groups[:ANALOG].LABELS[i])
+                        newlabel = ANALOG_LABELS[i][1:(m.offset - 1)] *
+                            string('_', tryparse(Int, m[:num]) + 1)
+                        ANALOG_LABELS[i] = newlabel
+                        push!(dups, ANALOG_LABELS[i])
                     end
                 end
             end
         end
     end # End if analog channels exist
 
-    nothing
+    return nothing
 end
 

--- a/test/identical.jl
+++ b/test/identical.jl
@@ -13,16 +13,16 @@ function comparefiles(reference, candidates)
                 end
                 @testset "Compare the :$(refc3d.groups[grp].symname) parameters" begin
                     for param in keys(refc3d.groups[grp].params)
-                        if eltype(refc3d.groups[grp].params[param].data) <: Number
+                        if eltype(refc3d.groups[grp].params[param].payload.data) <: Number
                             if grp == :POINT && param == :SCALE
-                                @test abs.(refc3d.groups[grp].params[param].data) ≈ abs.(file.groups[grp].params[param].data)
+                                @test abs.(refc3d.groups[grp].params[param].payload.data) ≈ abs.(file.groups[grp].params[param].payload.data)
                             elseif grp == :POINT && param == :DATA_START && any(basename(candfn) .== ("TESTBPI.c3d", "TESTCPI.c3d", "TESTDPI.c3d"))
-                                @test file.groups[grp].params[param].data == 20
+                                @test file.groups[grp].params[param].payload.data == 20
                             else
-                                @test refc3d.groups[grp].params[param].data ≈ file.groups[grp].params[param].data
+                                @test refc3d.groups[grp].params[param].payload.data ≈ file.groups[grp].params[param].payload.data
                             end
                         else
-                            @test reduce(*,refc3d.groups[grp].params[param].data .== file.groups[grp].params[param].data)
+                            @test reduce(*,refc3d.groups[grp].params[param].payload.data .== file.groups[grp].params[param].payload.data)
                         end
                     end
                 end

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1,0 +1,11 @@
+@testset "Inference" begin
+f = readc3d(joinpath(datadir, "sample01", "Eb015pr.c3d"))
+
+@test @inferred(f.groups[:ANALOG][Vector{Int16}, :OFFSET]) == fill(Int16(2048), 32)
+@test @inferred(f.groups[:ANALOG][Int16, :USED]) == 16
+
+# Test implicit conversion
+@test @inferred(f.groups[:ANALOG][Int, :USED]) == 16
+@test @inferred(f.groups[:ANALOG][Vector{Int}, :OFFSET]) == fill(2048, 32)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,5 @@ include("singledata.jl")
 include("invalid.jl")
 include("blanklabels.jl")
 include("badformats.jl")
+include("inference.jl")
 


### PR DESCRIPTION
The `getproperty` syntax to access the data in a parameter, e.g.
`f.groups[:POINT].RATE` caused type instability (due to the parameter
data possibly being any number of types, String, Vector{Float32}, Int16,
etc). This type instability also affected accessing `Group` fields using
the dot syntax. (`getfield` would not have been affected.)

The root cause of the type instability is that the type
of the `params` Dictionary in each `Group` must be not fully concrete, since groups will have any
number of parameters with different types. However, some types can be
assumed based on the group/name (e.g. POINT:USED should always be an
integer). My solution is to add a typed `getindex` that type asserts
the return type: `f.groups[:POINT][Int, :USED]`. This solves the type
instability, while maintaining the ability to access parameters even when
you don't know or care to assert the type: `f.groups[:POINT][:USED]`.

This (and a few other inference related changes) is responsible for dramatically improving the "first run" time and reducing allocations as well.

Benchmarks:
```julia
#master
julia> @time readc3d("data/sample01/Eb015pr.c3d")
  1.866162 seconds (5.28 M allocations: 303.120 MiB, 3.61% gc time, 14.19% compilation time)

julia> @benchmark readc3d("data/sample01/Eb015pr.c3d")
BenchmarkTools.Trial:
  memory estimate:  2.85 MiB
  allocs estimate:  24863
  --------------
  minimum time:     2.247 ms (0.00% GC)
  median time:      2.309 ms (0.00% GC)
  mean time:        2.460 ms (4.77% GC)
  maximum time:     4.668 ms (46.08% GC)
  --------------
  samples:          2032
  evals/sample:     1
```

```julia
#PR
julia> @time readc3d("data/sample01/Eb015pr.c3d")
  1.019505 seconds (2.80 M allocations: 159.463 MiB, 4.10% gc time, 23.21% compilation time)

julia> @benchmark readc3d("data/sample01/Eb015pr.c3d")
BenchmarkTools.Trial:
  memory estimate:  1.84 MiB
  allocs estimate:  5295
  --------------
  minimum time:     821.959 μs (0.00% GC)
  median time:      861.177 μs (0.00% GC)
  mean time:        922.916 μs (5.83% GC)
  maximum time:     2.498 ms (59.99% GC)
  --------------
  samples:          5416
  evals/sample:     1
```
