### PR TITLE
Check marker name uniqueness when stripping prefixes

### DIFF
--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -33,6 +33,7 @@ function C3DFile(name::String, header::Header, groups::Dict{Symbol,Group},
 
     l = size(point, 1)
     allpoints = 1:l
+    numpts = groups[:POINT][Int, :USED]
 
     if strip_prefixes
         if haskey(groups, :SUBJECTS) && groups[:SUBJECTS][Int, :USES_PREFIXES] == 1
@@ -41,9 +42,11 @@ function C3DFile(name::String, header::Header, groups::Dict{Symbol,Group},
         else
             rgx = r":(?<label>\w*)"
         end
+        allunique(map(x -> something(something(match(rgx, x), (;label=nothing))[:label], x),
+            groups[:POINT][Vector{String}, :LABELS][1:numpts])) ||
+            throw(ArgumentError("marker names would not be unique after removing subject prefixes"))
     end
 
-    numpts = groups[:POINT][Int, :USED]
     if !iszero(numpts)
         for (idx, ptname) in enumerate(groups[:POINT][Vector{String}, :LABELS][1:numpts])
             if strip_prefixes

--- a/test/publicinterface.jl
+++ b/test/publicinterface.jl
@@ -1,0 +1,6 @@
+@testset "readc3d kwargs, etc" begin
+    @test f = readc3d(artifact"sample03/gait-pig.c3d"; strip_prefixes=true) isa C3DFile
+
+    # issue #11
+    @test_throws ArgumentError readc3d(artifact"sample00/Vicon Motion Systems/TableTennis.c3d"; strip_prefixes=true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ using C3D, Test, LazyArtifacts
 # sample32 - Data collection errors                         https://www.c3d.org/data/Sample32.zip
 
 include("identical.jl")
+include("publicinterface.jl")
 include("validate.jl")
 include("bigdata.jl")
 include("singledata.jl")


### PR DESCRIPTION
Fixes #11.
