### PR TITLE
Improve test coverage

### DIFF
--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -410,7 +410,18 @@ function _readparams(fn::String, io::IOStream)
     end
 
     for param in ps
-        groups[gids[param.gid]].params[param.symname] = param
+        if haskey(gids, param.gid)
+            groups[gids[param.gid]].params[param.symname] = param
+        else
+            groupsym = Symbol("GID_$(param.gid)_MISSING")
+            if !haskey(groups, groupsym)
+                groupname = string(groupsym)
+                groups[groupsym] = Group(0, Int8(length(groupname)), false, param.gid,
+                    groupname, groupsym, Int16(0), UInt8(31), "Group was not defined in header",
+                    Dict{Symbol,Parameter}())
+            end
+            groups[groupsym].params[param.symname] = param
+        end
     end
 
     return (groups, header, FEND, FType)

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -256,10 +256,6 @@ Read the C3D file at `fn`.
 """
 function readc3d(fn::AbstractString; paramsonly=false, validate=true,
                  missingpoints=true, strip_prefixes=false)
-    if !isfile(fn)
-        error("File ", fn, " cannot be found")
-    end
-
     io = open(fn, "r")
 
     groups, header, FEND, FType = _readparams(fn, io)

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -265,6 +265,8 @@ function readc3d(fn::AbstractString; paramsonly=false, validate=true,
         point = Dict{String,Array{Union{Missing, Float32},2}}()
         residual = Dict{String,Array{Union{Missing, Float32},1}}()
         analog = Dict{String,Array{Float32,1}}()
+        close(io)
+        return C3DFile(fn, header, groups, point, residual, analog)
     else
         (point, residual, analog) = readdata(io, groups, FEND, FType)
     end

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -286,7 +286,7 @@ function readc3d(fn::AbstractString; paramsonly=false, validate=true,
     return res
 end
 
-function _readparams(fn::String, io::IOStream)
+function _readparams(fn::String, io::IO)
     params_ptr = read(io, UInt8)
 
     if read(io, UInt8) != 0x50

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -109,8 +109,12 @@ function numpointframes(groups::Dict{Symbol,Group})::Int
 end
 
 function numanalogframes(f::C3DFile)
-    aspf = convert(Int, f.groups[:ANALOG][Float32, :RATE]/f.groups[:POINT][Float32, :RATE])
-    return numpointframes*aspf
+    if iszero(f.groups[:ANALOG][Int, :USED])
+        return 0
+    else
+        aspf = convert(Int, f.groups[:ANALOG][Float32, :RATE]/f.groups[:POINT][Float32, :RATE])
+        return numpointframes(f)*aspf
+    end
 end
 
 function Base.show(io::IO, f::C3DFile)

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -36,6 +36,7 @@ function typedindex(g::Group, ::Type{T}, k) where T
     return r
 end
 
+Base.keys(g::Group) = keys(g.params)
 Base.haskey(g::Group, key) = haskey(g.params, key)
 
 # TODO: Add get! method?

--- a/src/util.jl
+++ b/src/util.jl
@@ -66,6 +66,13 @@ function writetrc(io, f::C3DFile;
         isempty(mkrnames) && @warn "no markers matched subject $subject"
     end
 
+    if !isdisjoint(keys(f.groups[:POINT]), (:ANGLES, :POWERS, :FORCES, :MOMENTS))
+        nonmarkers = reduce(vcat,
+            [ f.groups[:POINT][Vector{String}, key] for key in keys(f.groups[:POINT])
+                if key ∈ (:ANGLES, :POWERS, :FORCES, :MOMENTS) ])
+        filter!(!in(nonmarkers), mkrnames)
+    end
+
     if strip_prefixes
         # Assume that LABEL_PREFIXES are used if present despite absence of USES_PREFIXES
         # prompted by a c3d file from OptiTrack Motive 2.2.0

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -243,6 +243,22 @@ function validatec3d(header::Header, groups::Dict{Symbol,Group})
         end
     end # End if analog channels exist
 
+    missing_groups = filter(!isnothing, map(x -> match(r"GID_(\d+)_MISSING", string(x)), collect(keys(groups))))
+
+    if !isempty(missing_groups)
+        for grp in missing_groups
+            if issubset(keys(groups[Symbol(grp.match)]), (:ACTUAL_START_FIELD, :ACTUAL_END_FIELD))
+                if !haskey(groups, :TRIAL)
+                    groups[:TRIAL] = Group(0, Int8(5), false, tryparse(Int8, grp[1]),
+                        "TRIAL", :TRIAL, Int16(0), UInt8(0), "",
+                        Dict{Symbol,Parameter}())
+                end
+                merge!(groups[:TRIAL].params, groups[Symbol(grp.match)].params)
+                delete!(groups, Symbol(grp.match))
+            end
+        end
+    end
+
     return nothing
 end
 

--- a/test/publicinterface.jl
+++ b/test/publicinterface.jl
@@ -1,6 +1,14 @@
 @testset "readc3d kwargs, etc" begin
-    @test f = readc3d(artifact"sample03/gait-pig.c3d"; strip_prefixes=true) isa C3DFile
+    @test readc3d(artifact"sample03/gait-pig.c3d"; strip_prefixes=true) isa C3DFile
 
     # issue #11
     @test_throws ArgumentError readc3d(artifact"sample00/Vicon Motion Systems/TableTennis.c3d"; strip_prefixes=true)
+
+    # C3D length
+    @test numpointframes(readc3d(artifact"sample36/18124framesi.c3d")) == 18124
+    @test numpointframes(readc3d(artifact"sample36/18124framesf.c3d")) == 18124
+    @test numpointframes(readc3d(artifact"sample36/36220framesi.c3d")) == 36220
+    @test numpointframes(readc3d(artifact"sample36/36220framesf.c3d")) == 36220
+    @test numpointframes(readc3d(artifact"sample36/72610framesi.c3d")) == 65535 # C3D.org mislabeled; confirmed via inspection in hex editor
+    @test numpointframes(readc3d(artifact"sample36/72610framesf.c3d")) == 65535 # same for this one
 end

--- a/test/publicinterface.jl
+++ b/test/publicinterface.jl
@@ -1,4 +1,6 @@
 @testset "readc3d kwargs, etc" begin
+    @test readc3d(artifact"sample01/Eb015pr.c3d"; paramsonly=true) isa C3DFile
+    @test readc3d(artifact"sample01/Eb015pr.c3d"; paramsonly=true, validate=false) isa C3DFile
     @test readc3d(artifact"sample03/gait-pig.c3d"; strip_prefixes=true) isa C3DFile
 
     # issue #11

--- a/test/publicinterface.jl
+++ b/test/publicinterface.jl
@@ -13,4 +13,8 @@
     @test numpointframes(readc3d(artifact"sample36/36220framesf.c3d")) == 36220
     @test numpointframes(readc3d(artifact"sample36/72610framesi.c3d")) == 65535 # C3D.org mislabeled; confirmed via inspection in hex editor
     @test numpointframes(readc3d(artifact"sample36/72610framesf.c3d")) == 65535 # same for this one
+
+    @test numanalogframes(readc3d(artifact"sample36/18124framesi.c3d")) == 0
+    @test numanalogframes(readc3d(artifact"sample01/Eb015pr.c3d")) == 1800
+
 end

--- a/test/publicinterface.jl
+++ b/test/publicinterface.jl
@@ -17,4 +17,7 @@
     @test numanalogframes(readc3d(artifact"sample36/18124framesi.c3d")) == 0
     @test numanalogframes(readc3d(artifact"sample01/Eb015pr.c3d")) == 1800
 
+    f = readc3d(artifact"sample01/Eb015pr.c3d")
+    @test show(devnull, f) == nothing
+    @test show(devnull, MIME("text/plain"), f) == nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,4 +48,5 @@ include("invalid.jl")
 include("blanklabels.jl")
 include("badformats.jl")
 include("inference.jl")
+include("utils.jl")
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,31 @@
+@testset "TRC" begin
+    mktemp() do path, io
+        @test writetrc(path, readc3d(artifact"sample01/Eb015pr.c3d")) == nothing
+    end
+    mktemp() do path, io
+        f = readc3d(artifact"sample01/Eb015pr.c3d")
+        @test writetrc(path, f; virtual_markers=Dict("TEST1" => similar(f.point[first(keys(f.point))]))) == nothing
+    end
+
+    f = readc3d(artifact"sample03/gait-pig.c3d")
+    mktemp() do path, io
+        @test writetrc(path, f; strip_prefixes=false, remove_unlabeled_markers=false) == nothing
+    end
+    mktemp() do path, io
+        @test writetrc(path, f; subject="A22", strip_prefixes=false, remove_unlabeled_markers=false) == nothing
+    end
+    mktemp() do path, io
+        @test writetrc(path, f; strip_prefixes=true, remove_unlabeled_markers=false) == nothing
+    end
+    mktemp() do path, io
+        @test writetrc(path, f; strip_prefixes=true, remove_unlabeled_markers=true) == nothing
+    end
+
+    f = readc3d(artifact"sample03/gait-pig-nz.c3d") # Contains unlabeled markers
+    mktemp() do path, io
+        @test writetrc(path, f; strip_prefixes=true, remove_unlabeled_markers=false) == nothing
+    end
+    mktemp() do path, io
+        @test writetrc(path, f; strip_prefixes=true, remove_unlabeled_markers=true) == nothing
+    end
+end

--- a/test/validate.jl
+++ b/test/validate.jl
@@ -1,4 +1,11 @@
-@testset "Groups validation" begin
+@testset "Validation" begin
+    let
+        io = IOBuffer(zeros(UInt8, 10))
+        path, _io = mktemp()
+        close(_io)
+        @test_throws r"not a valid C3D file" C3D._readparams(path, io)
+    end
+
     using C3D: validatec3d, MissingParametersError, MissingGroupsError
     f = readc3d(joinpath(artifact"sample01", "Eb015pr.c3d"))
     header, groups = f.header, f.groups


### PR DESCRIPTION
- Fix error when using `paramsonly=true`
- Fix numpointframes when TRIAL:LONG_FRAMES is stored as float
- Recover in presence of parameters for undeclared group
- Add tests for numpointframes, covers bugfixes in last 2 commits
