### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,10 @@ version = "0.7.3"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 VaxData = "a6f58a78-e649-57e2-81bc-1d865c7b74f7"
 
 [compat]
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 VaxData = "0.5,0.6,1"
 julia = "1.8"

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -1,6 +1,6 @@
 module C3D
 
-using VaxData, SnoopPrecompile, LazyArtifacts
+using VaxData, PrecompileTools, LazyArtifacts
 
 @enum Endian LE=1 BE=2
 
@@ -500,10 +500,10 @@ function _readparams(fn::String, io::IO)
     return (groups, header, FEND, FType)
 end
 
-@precompile_setup begin
+@setup_workload begin
     path, io = mktemp()
     close(io)
-    @precompile_all_calls begin
+    @compile_workload begin
         f = readc3d(joinpath(artifact"sample01", "Eb015pr.c3d"))
             readc3d(joinpath(artifact"sample01", "Eb015pi.c3d"))
             readc3d(joinpath(artifact"sample01", "Eb015sr.c3d"))


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
