### PR TITLE
Avoid passing an Int to stat

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -26,7 +26,7 @@ function readdata(
     end
 
     est_data_size = numframes*sizeof(F)*(nummarkers*4 + numchannels*aspf)
-    _iosize = stat(fd(io)).size
+    _iosize = stat(RawFD(fd(io))).size
     rem_file_size = _iosize - position(io)
     if est_data_size > rem_file_size
         @debug "Estimated DATA size: $(Base.format_bytes(est_data_size)); \

--- a/src/read.jl
+++ b/src/read.jl
@@ -26,7 +26,7 @@ function readdata(
     end
 
     est_data_size = numframes*sizeof(F)*(nummarkers*4 + numchannels*aspf)
-    _iosize = stat(RawFD(fd(io))).size
+    _iosize = stat(io).size
     rem_file_size = _iosize - position(io)
     if est_data_size > rem_file_size
         @debug "Estimated DATA size: $(Base.format_bytes(est_data_size)); \


### PR DESCRIPTION
This accommodates an upstream change to Julia (JuliaLang/julia#54855) which will, if merged, reduce confusion about `stat` and related methods. Specifically, by deprecating and/or removing the `stat(::Int)` method, in favor of `stat(::RawFD)`, we avoid issues like `ispath(4)` returning `true` (JuliaLang/julia#51710).

The current implementation of `stat` is, according to `@less stat(4)`, `stat(fd::Integer) = stat(RawFD(fd))`. So this PR should not change the functionality of this package.

https://github.com/JuliaLang/julia/blob/c3883824b00f378b7e2609c5e20f4a110e5e56e6/base/stat.jl#L192