### PR TITLE
Validate C3DFile before writing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,20 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - main
+      - 'release*'
+  pull_request:
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -23,19 +36,12 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
+

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.8.0-DEV"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 VaxData = "a6f58a78-e649-57e2-81bc-1d865c7b74f7"
 

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -227,7 +227,7 @@ function Header{END}(f::C3DFile{OEND}) where {END<:AbstractEndian,OEND<:Abstract
     end
     ampf::UInt16 = aspf*f.groups[:ANALOG][Int, :USED]
 
-    datastart::UInt8 = 2+round(sum(writesize, Iterators.flatten((groups(f), parameters(f))))/512, RoundUp)
+    datastart::UInt8 = 2+cld(sum(writesize, Iterators.flatten((groups(f), parameters(f)))), 512)
 
     return Header{END}(paramptr, datafmt, npoints, ampf, h.fframe, h.lframe, h.maxinterp,
         h.scale, datastart, aspf, pointrate, h.res1, h.labeltype, h.numevents, h.res2,

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -211,8 +211,8 @@ end
 
 endianness(f::C3DFile{END}) where END = END
 
-groups(f::C3DFile) = collect(values(f.groups))
-parameters(f::C3DFile) = collect(Iterators.flatten((values(group) for group in groups(f))))
+groups(f::C3DFile) = values(f.groups)
+parameters(f::C3DFile) = Iterators.flatten((values(group) for group in groups(f)))
 
 function Header{END}(f::C3DFile{OEND}) where {END<:AbstractEndian,OEND<:AbstractEndian}
     h = f.header

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -42,8 +42,6 @@ function C3DFile(name::String, header::Header, groups::LittleDict{Symbol,Group},
     cameras = OrderedDict{String,Vector{UInt8}}()
     fanalog = OrderedDict{String,Vector{Float32}}()
 
-    l = size(point, 1)
-    allpoints = 1:l
     numpts = groups[:POINT][Int, :USED]
 
     ptlabel_keys = get_multipled_parameter_names(groups, :POINT, :LABELS)
@@ -64,6 +62,10 @@ function C3DFile(name::String, header::Header, groups::LittleDict{Symbol,Group},
 
     nolabel_count = 1
     if !iszero(numpts)
+        sizehint!(fpoint, numpts)
+        sizehint!(fresiduals, numpts)
+        sizehint!(cameras, numpts)
+
         invalidpoints = Vector{Bool}(undef, size(point, 1))
         calculatedpoints = Vector{Bool}(undef, size(point, 1))
         goodpoints = Vector{Bool}(undef, size(point, 1))
@@ -127,10 +129,12 @@ function C3DFile(name::String, header::Header, groups::LittleDict{Symbol,Group},
     an_labels = Iterators.flatten(
         groups[:ANALOG][Vector{String}, label] for label in anlabel_keys
         )
+
     numanalogs = groups[:ANALOG][Int, :USED]
 
     nolabel_count = 1
     if !iszero(numanalogs)
+        sizehint!(fanalog, numanalogs)
         for (idx, name) in enumerate(an_labels)
             idx > numanalogs && break # can't slice Iterators.flatten
             og_name = name

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -26,15 +26,6 @@ include("validate.jl")
 include("write.jl")
 include("util.jl")
 
-function _naturalsortby(x)
-    m = match(r"(\d+)$", string(x))
-    if isnothing(m)
-        return typemin(Int)
-    else
-        return Base.parse(Int, m[1])
-    end
-end
-
 struct DuplicateMarkerError
     msg::String
 end
@@ -55,10 +46,7 @@ function C3DFile(name::String, header::Header, groups::Dict{Symbol,Group},
     allpoints = 1:l
     numpts = groups[:POINT][Int, :USED]
 
-    ptlabel_keys = collect(filter(keys(groups[:POINT])) do k
-        contains(string(k), r"^LABELS\d*")
-    end)
-    sort!(ptlabel_keys; by=_naturalsortby)
+    ptlabel_keys = get_multipled_parameter_names(groups, :POINT, :LABELS)
     pt_labels = Iterators.flatten(
         groups[:POINT][Vector{String}, label] for label in ptlabel_keys
         )

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -225,7 +225,7 @@ function Header{END}(f::C3DFile{OEND}) where {END<:AbstractEndian,OEND<:Abstract
     end
     ampf::UInt16 = aspf*f.groups[:ANALOG][Int, :USED]
 
-    datastart::UInt8 = 2+cld(sum(writesize, Iterators.flatten((groups(f), parameters(f)))), 512)
+    datastart::UInt8 = 2+cld(sum(writesize, Iterators.flatten((groups(f), parameters(f))))+4, 512)
 
     return Header{END}(paramptr, datafmt, npoints, ampf, h.fframe, h.lframe, h.maxinterp,
         h.scale, datastart, aspf, pointrate, h.res1, h.labeltype, h.numevents, h.res2,

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -108,9 +108,9 @@ function C3DFile(name::String, header::Header{END}, groups::LittleDict{Symbol,Gr
 
             fpoint[ptname] = point[:,((idx-1)*3+1):((idx-1)*3+3)]
             fresiduals[ptname] = residuals[:,idx]
-            cameras[ptname] = ((convert.(Int32, @view(residuals[:,idx])) .>> 8) .& 0xff) .% UInt8
-            invalidpoints .= convert.(Int32, fresiduals[ptname]) .% Int16 .< 0
-            calculatedpoints .= iszero.(fresiduals[ptname])
+            cameras[ptname] = ((@view(residuals[:,idx]) .>> 8) .% UInt8) .& 0x7f
+            invalidpoints .= ((@view(residuals[:,idx]) .% UInt16) .& 0x8000) .!== 0x0000
+            calculatedpoints .= iszero.(@view(residuals[:,idx]) .& 0xff)
             goodpoints .= .~(invalidpoints .| calculatedpoints)
             calcresiduals!(fresiduals[ptname], goodpoints, abs(groups[:POINT][Float32, :SCALE]))
 

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -116,15 +116,13 @@ function C3DFile(name::String, header::Header{END}, groups::LittleDict{Symbol,Gr
 
             if missingpoints
                 for i in eachindex(fresiduals[ptname])
+                    if calculatedpoints[i] & ~invalidpoints[i]
+                        fresiduals[ptname][i] = 0.0f0
+                    end
+
                     if invalidpoints[i]
                         fpoint[ptname][i, :] .= missing
                         fresiduals[ptname][i] = missing
-                    end
-                end
-
-                for i in eachindex(fresiduals[ptname])
-                    if calculatedpoints[i]
-                        fresiduals[ptname][i] = 0.0f0
                     end
                 end
             end

--- a/src/C3D.jl
+++ b/src/C3D.jl
@@ -95,7 +95,7 @@ function C3DFile(name::String, header::Header{END}, groups::LittleDict{Symbol,Gr
                 while ptname*"_$cnt" ∈ keys(fpoint); cnt+=1 end
                 ptname *= "_$cnt"
                 dedupped_ptname = ptname
-                @warn "Duplicate marker label detected (\"$(og_ptname)\"). Duplicate renamed to \"$dedupped_ptname\"."
+                @warn "Duplicate marker label detected (\"$(og_ptname)\"). Duplicate renamed to \"$dedupped_ptname\"." _id=dedupped_ptname
             end
             ptname ∉ keys(fpoint) || throw(DuplicateMarkerError(
                 "Markers labels must be unique but found duplicate marker label \"$ptname\""*
@@ -158,7 +158,7 @@ function C3DFile(name::String, header::Header{END}, groups::LittleDict{Symbol,Gr
                 while name*"_$cnt" ∈ keys(fanalog); cnt+=1 end
                 name *= "_$cnt"
                 dedupped_name = name
-                @warn "Duplicate analog signal label detected (\"$(og_name)\"). Duplicate renamed to \"$dedupped_name\"."
+                @warn "Duplicate analog signal label detected (\"$(og_name)\"). Duplicate renamed to \"$dedupped_name\"." _id=dedupped_name
             end
 
             fanalog[name] = analog[:, idx]

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -76,11 +76,22 @@ Base.haskey(g::Group, key) = haskey(g.params, key)
 
 # TODO: Add get! method?
 function Base.get(g::Group, key, default)
-    _key = key isa Tuple ? last(key) : key
+    return haskey(g, key) ? g[key] : default
+end
+function Base.get(g::Group, key::Tuple{Type,Symbol}, default::T) where T
+    _key = last(key)
     return haskey(g, _key) ? g[key...] : default
 end
 
-Base.show(io::IO, g::Group) = show(io, keys(g.params))
+
+function Base.show(io::IO, g::Group)
+    print(io, "Group(:$(g.name)) ")
+    if isempty(keys(g.params))
+        print(io, "[]")
+    else
+        print(io, keys(g.params))
+    end
+end
 
 function Base.show(io::IO, ::MIME"text/plain", g::Group)
     print(io, "Group(:$(g.name))")

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -4,7 +4,7 @@ mutable struct Group{END<:AbstractEndian}
     gid::Int8 # Group ID
     const locked::Bool
     const _name::Vector{UInt8} # Character set should be A-Z, 0-9, and _ (lowercase is ok)
-    const name::Symbol
+    name::Symbol
     const np::Int16 # Pointer in bytes to the start of next group/parameter (officially supposed to be signed)
     const _desc::Vector{UInt8} # Character set should be A-Z, 0-9, and _ (lowercase is ok)
     const params::LittleDict{Symbol,Parameter}
@@ -37,6 +37,10 @@ end
 
 function Group(name::String, desc::String, params=LittleDict{Symbol,Parameter}(); gid=0, locked=signbit(gid))
     return Group{LE{Float32}}(0, gid, locked, name, 0, desc, params)
+end
+
+function Base.:(==)(g1::Group, g2::Group)
+    return g1.gid === g2.gid && g1.name === g2.name && g1.params == g2.params
 end
 
 function Base.getindex(g::Group, k::Symbol)

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -7,35 +7,35 @@ mutable struct Group{END<:AbstractEndian}
     const name::Symbol
     const np::Int16 # Pointer in bytes to the start of next group/parameter (officially supposed to be signed)
     const _desc::Vector{UInt8} # Character set should be A-Z, 0-9, and _ (lowercase is ok)
-    const params::Dict{Symbol,Parameter}
+    const params::LittleDict{Symbol,Parameter}
 end
 
 function Group(
     pos::Int, gid::Int8, locked::Bool, _name::Vector{UInt8}, name::Symbol, np::Int16,
-    _desc::Vector{UInt8}, params::Dict{Symbol,Parameter}
+    _desc::Vector{UInt8}, params::LittleDict{Symbol,Parameter}
 )
     return Group{LE{Float32}}(pos, gid, locked, _name, name, np, _desc, params)
 end
 
 function Group{END}(
-    pos, gid, locked, name, np, desc, params=Dict{Symbol,Parameter}()
+    pos, gid, locked, name, np, desc, params=LittleDict{Symbol,Parameter}()
 ) where {END<:AbstractEndian}
     return Group{END}(pos, convert(Int8, gid), locked, Vector{UInt8}(name), Symbol(name),
         convert(Int16, np), Vector{UInt8}(desc), params)
 end
 
-function Group(pos, gid, locked, name, np, desc, params=Dict{Symbol,Parameter}())
+function Group(pos, gid, locked, name, np, desc, params=LittleDict{Symbol,Parameter}())
     return Group{LE{Float32}}(pos, convert(Int8, gid), locked, Vector{UInt8}(name),
         Symbol(name), convert(Int16, np), Vector{UInt8}(desc), params)
 end
 
 function Group{END}(
-    name::String, desc::String, params=Dict{Symbol,Parameter}(); gid=0, locked=signbit(gid)
+    name::String, desc::String, params=LittleDict{Symbol,Parameter}(); gid=0, locked=signbit(gid)
 ) where {END<:AbstractEndian}
     return Group{END}(0, gid, locked, name, 0, desc, params)
 end
 
-function Group(name::String, desc::String, params=Dict{Symbol,Parameter}(); gid=0, locked=signbit(gid))
+function Group(name::String, desc::String, params=LittleDict{Symbol,Parameter}(); gid=0, locked=signbit(gid))
     return Group{LE{Float32}}(0, gid, locked, name, 0, desc, params)
 end
 
@@ -117,7 +117,7 @@ function Base.read(io::IO, ::Type{Group{END}}) where {END<:AbstractEndian}
 
     pointer = pos + np + abs(nl) + 2
     @debug "wrong pointer in $name" position(io), pointer maxlog=(position(io) != pointer)
-    return Group{END}(pos, gid, locked, _name, name, np, desc, Dict{Symbol,Parameter}())
+    return Group{END}(pos, gid, locked, _name, name, np, desc, LittleDict{Symbol,Parameter}())
 end
 
 function Base.write(io::IO, g::Group{END}; last::Bool=false) where {END}

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -8,6 +8,13 @@ mutable struct Group{END<:AbstractEndian}
     name::Symbol
     const _desc::Vector{UInt8} # Character set should be A-Z, 0-9, and _ (lowercase is ok)
     const params::LittleDict{Symbol,Parameter,Vector{Symbol},Vector{Parameter}}
+
+    function Group{END}(
+        pos::Int, gid::Int8, locked::Bool, np::Int16, _name::Vector{UInt8}, name::Symbol,
+        _desc::Vector{UInt8},
+        params::LittleDict{Symbol,Parameter,Vector{Symbol},Vector{Parameter}}) where {END}
+        return new{END}(pos, copysign(gid, -1), locked, np, _name, name, _desc, params)
+    end
 end
 
 function Group(
@@ -141,7 +148,7 @@ end
 function Base.write(io::IO, g::Group{END}; last::Bool=false) where {END}
     nb = 0
     nb += write(io, flipsign(UInt8(length(g._name)), -1*g.locked))
-    nb += write(io, g.gid)
+    nb += write(io, copysign(g.gid, -1))
     nb += write(io, g._name)
     nb += write(io, last ? 0x0000 : END(Int16)(UInt16(length(g._desc) + 3)))
     nb += write(io, UInt8(length(g._desc)))

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -271,7 +271,7 @@ function _readarrayparameter(io::IO, ::Type{<:AbstractEndian{String}}, dims)::Ar
             data[ijk] = String(copy(rstrip_cntrl_null_space(@view tdata[:, ijk])))
         end
     else
-        data = [ rstrip(String(tdata)) ]
+        data = [ rstrip(x -> iscntrl(x) || isspace(x), transcode(String, tdata)) ]
     end
     return data
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -14,7 +14,7 @@ mutable struct Parameter{P<:AbstractParameter}
     gid::Int8 # Group ID
     const locked::Bool # Locked if nl < 0
     const _name::Vector{UInt8} # Character set should be A-Z, 0-9, and _ (lowercase is ok)
-    const name::Symbol
+    name::Symbol
     const np::Int16 # Pointer in bytes to the start of next group/parameter (officially supposed to be signed)
     const _desc::Vector{UInt8} # Character set should be A-Z, 0-9, and _ (lowercase is ok)
     const payload::P
@@ -80,6 +80,18 @@ end
 function Base.unsigned(p::ScalarParameter{T}) where T
     uT = unsigned(T)
     return ScalarParameter{uT}(unsigned(p.data))
+end
+
+function Base.:(==)(p1::Parameter, p2::Parameter)
+    return p1.gid === p2.gid && p1.name === p2.name && typeof(p1.payload) === typeof(p2.payload) &&
+        p1.payload.data == p2.payload.data
+end
+
+function Base.hash(p::Parameter, h::UInt)
+    h = hash(p.gid, h)
+    h = hash(hash(p.name), h)
+    h = hash(p.payload.data, h)
+    return h
 end
 
 function Base.show(io::IO, p::Parameter{P}) where P

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -124,7 +124,7 @@ function Base.show(io::IO, p::Parameter{P}) where P
         if _ndims(p) > 1
             printstyled(io, "@ $(_size(p)[2:end]) "; bold=true, color=:light_black)
         end
-    elseif _ndims(p) > 1
+    elseif prod(_size(p)) > 1
         printstyled(io, "@ $(_size(p)) "; bold=true, color=:light_black)
     end
 
@@ -132,7 +132,7 @@ function Base.show(io::IO, p::Parameter{P}) where P
     if elt <: String && _ndims(p) == 1
         print(io, repr(p.payload.data))
     else
-        print(io, p.payload.data)
+        print(IOContext(io, :compact=>true), p.payload.data)
     end
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -59,7 +59,7 @@ function Parameter(name, desc, payload::AbstractArray{T,N}; gid=0, locked=signbi
         ArrayParameter{T,N}(sizeof(T), ndims(payload), size(payload), payload))
 end
 
-function Parameter(name, desc, payload::T; gid=0, locked=signbit(gid)) where {T}
+function Parameter(name, desc, payload::T; gid=0, locked=signbit(gid)) where {T <: Union{UInt8,UInt16,Float32}}
     return Parameter(0, gid, locked, 0, name, desc, ScalarParameter{T}(payload))
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -140,7 +140,7 @@ function Base.show(io::IO, ::MIME"text/plain", p::Parameter{P}) where P
     print(io, "Parameter(:$(p.name)")
     if !isempty(p._desc)
         print(io, ", ")
-        printstyled(io, "\"", transcode(String, copy(p._desc)), "\""; color=:light_black)
+        printstyled(io, "\"", transcode(String, transcode(UInt16, copy(p._desc))), "\""; color=:light_black)
     end
     print(io, ")")
     elsize = _elsize(p)
@@ -256,11 +256,7 @@ function readparam(io::IO, ::Type{END}) where {END<:AbstractEndian}
     end
 
     dl = read(io, UInt8)::UInt8
-    desc = read(io, dl)
-
-    if any(iscntrl∘Char, desc)
-        desc = UInt8[]
-    end
+    desc = copy(rstrip_cntrl_null_space(read(io, dl)))
 
     pointer = pos + np + abs(nl) + 2
     # @debug "wrong pointer in $name" position(io) pointer maxlog=(position(io) != pointer)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -380,7 +380,11 @@ function Base.write(
             end
         end
     else
-        nb += sum(write.(io, END(elt).(p.payload.data)))
+        if elt <: Integer
+            nb += sum(write.(io, END(elt).(p.payload.data .% elt)))
+        else
+            nb += sum(write.(io, END(elt).(p.payload.data)))
+        end
     end
 
     nb += write(io, UInt8(length(p._desc)))

--- a/src/read.jl
+++ b/src/read.jl
@@ -129,9 +129,25 @@ function readdata(
             SCALE = groups[:ANALOG][Float32, :GEN_SCALE] * groups[:ANALOG][Float32, :SCALE]
             analog .= (analog .- ANALOG_OFFSET) .* SCALE
         else
-            VECANALOG_OFFSET = groups[:ANALOG][Vector{Int}, :OFFSET][1:numchannels]
-            VECSCALE = groups[:ANALOG][Float32, :GEN_SCALE] .*
-                            groups[:ANALOG][Vector{Float32}, :SCALE][1:numchannels]
+            off_labels = get_multipled_parameter_names(groups, :ANALOG, :OFFSET)
+            if length(off_labels) > 1
+                VECANALOG_OFFSET = convert(Vector{Float32}, reduce(vcat,
+                    groups[:ANALOG][Vector{Int}, offset]
+                    for offset in off_labels))[1:numchannels]
+            else
+                VECANALOG_OFFSET = convert(Vector{Float32},
+                    groups[:ANALOG][Vector{Int}, :OFFSET][1:numchannels])
+            end
+
+            scale_labels = get_multipled_parameter_names(groups, :ANALOG, :SCALE)
+            if length(scale_labels) > 1
+                VECSCALE = convert(Vector{Float32}, reduce(vcat,
+                    groups[:ANALOG][Vector{Int}, scale]
+                    for scale in scale_labels))[1:numchannels]
+            else
+                VECSCALE = groups[:ANALOG][Vector{Float32}, :SCALE][1:numchannels]
+            end
+            VECSCALE .*= groups[:ANALOG][Float32, :GEN_SCALE]
 
             analog .= (analog .- VECANALOG_OFFSET) .* VECSCALE
         end

--- a/src/read.jl
+++ b/src/read.jl
@@ -345,7 +345,7 @@ function _readparams(io::IO, paramblocks, ::Type{END}, handle_duplicate_paramete
 
                     @warn "Multiple groups with the same name \"$(group.name)\" and \
 group ID `$(gid(group))`. The second duplicate group will be deleted to keep group names
-unique (no parameters will be lost)." _id=stat(fd(io)).desc maxlog=1
+unique (no parameters will be lost)." _id=(group.name, gid(group)) maxlog=1
 
                     # could be more than 1 duplicate
                     is = findall(==(group.name)∘(g->g.name), gs)
@@ -364,7 +364,7 @@ unique (no parameters will be lost)." _id=stat(fd(io)).desc maxlog=1
 
                     # @debug group isduplicate(group, gs; by=(g->g.name))
                     @warn "Multiple groups with the same name \"$(group.name)\". The \
-group ID will be appended to the duplicate group names to keep group names unique." _id=stat(fd(io)).desc maxlog=1
+group ID will be appended to the duplicate group names to keep group names unique." _id=group.name maxlog=1
                     dups = findall(==(group.name)∘(g->g.name), gs)
                     for i in dups
                         gs[i].name = Symbol(gs[i].name, "_", gid(gs[i]))

--- a/src/read.jl
+++ b/src/read.jl
@@ -3,7 +3,7 @@ function calcresiduals(x::AbstractVector, scale)
 end
 
 function readdata(
-    io::IOStream, h::Header{END}, groups::Dict{Symbol,Group}, ::Type{F}
+    io::IOStream, h::Header{END}, groups::LittleDict{Symbol,Group}, ::Type{F}
     ) where {END<:AbstractEndian, F}
     if iszero(groups[:POINT][Int, :DATA_START]-1)
         if !iszero(h.datastart-1)
@@ -148,10 +148,10 @@ function readc3d(fn::AbstractString; paramsonly=false, validate=true,
     end
 
     if paramsonly
-        point = Dict{String,Matrix{Union{Missing, Float32}}}()
-        residual = Dict{String,Vector{Union{Missing, Float32}}}()
-        cameras = Dict{String,Vector{UInt8}}()
-        analog = Dict{String,Vector{Float32}}()
+        point = OrderedDict{String,Matrix{Union{Missing, Float32}}}()
+        residual = OrderedDict{String,Vector{Union{Missing, Float32}}}()
+        cameras = OrderedDict{String,Vector{UInt8}}()
+        analog = OrderedDict{String,Vector{Float32}}()
         close(io)
         return C3DFile(fn, header, groups, point, residual, cameras, analog)
     else
@@ -205,7 +205,7 @@ function _readparams(fn::String, io::IO)
     header = read(io, Header{END})
     reset(io)
 
-    groups = Dict{Symbol,Group}()
+    groups = LittleDict{Symbol,Group}()
     if !iszero(paramblocks)
         gs = Array{Group,1}()
         ps = Array{Parameter,1}()
@@ -283,8 +283,8 @@ function _readparams(fn::String, io::IO)
             end
         end
 
-        groups = Dict{Symbol,Group}()
-        gids = Dict{Int8,Symbol}()
+        groups = LittleDict{Symbol,Group}()
+        gids = LittleDict{Int8,Symbol}()
 
         for group in gs
             groups[group.name] = group

--- a/src/read.jl
+++ b/src/read.jl
@@ -279,10 +279,10 @@ function _readparams(io::IO, paramblocks, ::Type{END}, handle_duplicate_paramete
             # Mark current position in file in case the pointer is incorrect
             mark(io)
             if fail === 0 && np != position(io)
-                    @debug "Pointer mismatch at position $(position(io)) where pointer was $np"
-                    seek(io, np)
+                @debug "Pointer mismatch at position $(string(position(io); base=16)) where pointer was $(string(np; base=16))"
+                seek(io, np)
             elseif fail > 1 # this is the second failed attempt
-                @debug "Second failed parameter read attempt from $(position(io))"
+                @debug "Second failed parameter read attempt from $(string(position(io); base=16))"
                 break
             end
 
@@ -302,7 +302,7 @@ function _readparams(io::IO, paramblocks, ::Type{END}, handle_duplicate_paramete
                         # Last readgroup failed, possibly due to a bad pointer. Reset to the ending
                         # location of the last successfully read parameter and try again. Count the failure.
                         reset(io)
-                        @debug "Read group failed, last parameter ended at $(position(io)), pointer at $np" fail exception=(e,catch_backtrace())
+                        @debug "Read group failed, last parameter ended at $(string(position(io); base=16)), pointer at $(string(np; base=16))" fail exception=(e,catch_backtrace())
                         fail += 1
                     else
                         rethrow(e)
@@ -322,7 +322,7 @@ function _readparams(io::IO, paramblocks, ::Type{END}, handle_duplicate_paramete
                 catch e
                     if e isa AssertionError || e isa ParameterTypeError
                         reset(io)
-                        @debug "Read group failed, last parameter ended at $(position(io)), pointer at $np" fail exception=(e,catch_backtrace())
+                        @debug "Read group failed, last parameter ended at $(string(position(io); base=16)), pointer at $(string(np; base=16))" fail exception=(e,catch_backtrace())
                         fail += 1
                     else
                         rethrow(e)

--- a/src/util.jl
+++ b/src/util.jl
@@ -8,9 +8,10 @@ function _naturalsortby(x)
 end
 
 function get_multipled_parameter_names(groups, group, param)
-    params = collect(filter(keys(groups[Symbol(group)])) do k
-        contains(string(k), Regex("^$(param)\\d*"))
-        end)
+    rgx = Regex("^$(param)\\d*")
+    params = filter(collect(keys(groups[Symbol(group)]))) do k
+        contains(string(k), rgx)
+    end
     sort!(params; by=_naturalsortby)
     return params
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -16,6 +16,24 @@ function get_multipled_parameter_names(groups, group, param)
     return params
 end
 
+"loosely based on countmap (addcounts_dict!) from StatsBase"
+function findduplicates(itr)
+    dups = Dict{eltype(itr), Int}()
+    for k in itr
+        index, sh = Base.ht_keyindex2_shorthash!(dups, k)
+        if index > 0
+            dups.age += 1
+            @inbounds dups.keys[index] = k
+            @inbounds dups.vals[index] += 1
+        else
+            @inbounds Base._setindex!(dups, 1, k, -index, sh)
+        end
+    end
+
+    filter!(((k,v),) -> v > 1, dups)
+    return collect(keys(dups))
+end
+
 const eye3 = [true false false;
               false true false;
               false false true]

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,3 +1,20 @@
+function _naturalsortby(x)
+    m = match(r"(\d+)$", string(x))
+    if isnothing(m)
+        return typemin(Int)
+    else
+        return Base.parse(Int, m[1])
+    end
+end
+
+function get_multipled_parameter_names(groups, group, param)
+    params = collect(filter(keys(groups[Symbol(group)])) do k
+        contains(string(k), Regex("^$(param)\\d*"))
+        end)
+    sort!(params; by=_naturalsortby)
+    return params
+end
+
 const eye3 = [true false false;
               false true false;
               false false true]

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -45,7 +45,7 @@ const pointsigncheck = ((:POINT, :USED),
 # const analogsigncheck = (:ANALOG, :USED)
 # const fpsigncheck = (:FORCE_PLATFORM, :ZERO)
 
-function validatec3d(header::Header, groups::LittleDict{Symbol,Group})
+function validatec3d(header, groups)
     # The following if-else ensures the minimum set of information needed to succesfully
     # read a C3DFile
 

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -167,13 +167,13 @@ function validatec3d(header, groups)
 
         # Pad scale and offset if shorter than :USED
         l = length(groups[:ANALOG][Vector{Float32}, :SCALE])
-        if l < ANALOG_USED
+        if l < ANALOG_USED && !haskey(groups[:ANALOG], :SCALE2)
             append!(groups[:ANALOG][Vector{Float32}, :SCALE],
                     fill(one(Float32), ANALOG_USED - l))
         end
 
         l = length(groups[:ANALOG][Vector{Int16}, :OFFSET])
-        if l < ANALOG_USED
+        if l < ANALOG_USED && !haskey(groups[:ANALOG], :OFFSET2)
             append!(groups[:ANALOG][Vector{Int16}, :OFFSET],
                     fill(one(Float32), ANALOG_USED - l))
         end

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -185,7 +185,7 @@ function validatec3d(header, groups)
         for grp in missing_groups
             if issubset(keys(groups[Symbol(grp.match)]), (:ACTUAL_START_FIELD, :ACTUAL_END_FIELD))
                 if !haskey(groups, :TRIAL)
-                    groups[:TRIAL] = Group("TRIAL", ""; gid=tryparse(Int8, grp[1]))
+                    groups[:TRIAL] = Group("TRIAL", ""; gid=-tryparse(Int8, grp[1]))
                 end
                 merge!(groups[:TRIAL].params, groups[Symbol(grp.match)].params)
                 delete!(groups, Symbol(grp.match))

--- a/src/validate.jl
+++ b/src/validate.jl
@@ -45,7 +45,7 @@ const pointsigncheck = ((:POINT, :USED),
 # const analogsigncheck = (:ANALOG, :USED)
 # const fpsigncheck = (:FORCE_PLATFORM, :ZERO)
 
-function validatec3d(header::Header, groups::Dict{Symbol,Group})
+function validatec3d(header::Header, groups::LittleDict{Symbol,Group})
     # The following if-else ensures the minimum set of information needed to succesfully
     # read a C3DFile
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -38,9 +38,7 @@ function writedata(io::IO, f::C3DFile{END}) where {END<:AbstractEndian}
     numchannels::Int = f.groups[:ANALOG][Int, :USED]
     aspf = h.aspf
 
-    analogdata = reduce(hcat, (f.analog[channel]
-        for channel in
-            f.groups[:ANALOG][Vector{String}, :LABELS][1:f.groups[:ANALOG][Int, :USED]]))
+    analogdata = reduce(hcat, (f.analog[channel] for channel in keys(f.analog) ))
     if numchannels == 1
         ANALOG_OFFSET = f.groups[:ANALOG][Float32, :OFFSET]
         SCALE = f.groups[:ANALOG][Float32, :GEN_SCALE] * f.groups[:ANALOG][Float32, :SCALE]
@@ -55,12 +53,10 @@ function writedata(io::IO, f::C3DFile{END}) where {END<:AbstractEndian}
     analog = permutedims(reshape(permutedims(analogdata), numchannels*aspf, :))
     if T <: Int16
         pointdata = reduce(hcat, ([roundapprox.(T, f.point[marker]./POINT_SCALE) makeresiduals(f, marker)]
-            for marker in
-                f.groups[:POINT][Vector{String}, :LABELS][1:f.groups[:POINT][Int, :USED]]))
+            for marker in keys(f.point) ))
     else
         pointdata = reduce(hcat, ([f.point[marker] makeresiduals(f, marker)]
-            for marker in
-                f.groups[:POINT][Vector{String}, :LABELS][1:f.groups[:POINT][Int, :USED]]))
+            for marker in keys(f.point) ))
     end
     missings = findall(ismissing, pointdata)
     if !isempty(missings)

--- a/src/write.jl
+++ b/src/write.jl
@@ -105,9 +105,10 @@ function writec3d(io, f::C3DFile{END}) where END
     nb += write(io, header)
     f.groups[:POINT].params[:DATA_START].payload.data = header.datastart
 
+    @debug "padding from  $(position(io)) to $(max((header.paramptr-1)*512 - position(io), 0)+position(io))"
     # pad with zeros until `paramptr`
     nb += sum(x -> write(io, x),
-        Iterators.repeated(0x00, max((f.header.paramptr-1)*512 - position(io), 0)); init=0)
+        Iterators.repeated(0x00, max((header.paramptr-1)*512 - position(io), 0)); init=0)
 
     # we may add groups and/or parameters during read validation; default gids for new
     # groups or parameters is zero
@@ -164,9 +165,9 @@ function writec3d(io, f::C3DFile{END}) where END
     # parameter section
     nb += write(io, last(params), END; last=true)
 
-    datastart = header.datastart*512
+    datastart = (header.datastart-1)*512
     # pad with zeros until the beginning of the data section
-    @debug "padding from  $(position(io)) to $(max(datastart - position(io), 0))"
+    @debug "padding from  $(position(io)) to $(max(datastart - position(io), 0)+position(io))"
     nb += sum(x -> write(io, x),
         Iterators.repeated(0x00, max(datastart - position(io), 0)); init=0)
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -83,7 +83,7 @@ function writec3d(filename::String, f::C3DFile)
     end
 end
 
-function writec3d(io, f::C3DFile{END}) where END
+function add_edited!(f::C3DFile{END}) where END
     get!(f.groups, :MANUFACTURER, Group{END}("MANUFACTURER", "Manufacturer information"))
     p = get!(f.groups[:MANUFACTURER].params, :EDITED, Parameter("EDITED", "C3D file edit record", ""))
     if p isa Parameter{ScalarParameter{String}}
@@ -97,6 +97,12 @@ function writec3d(io, f::C3DFile{END}) where END
         push!(p.payload.data, edited_desc())
     end
     f.groups[:MANUFACTURER].params[:EDITED] = p
+
+    return nothing
+end
+
+function writec3d(io, f::C3DFile{END}) where END
+    add_edited!(f)
 
     nb = 0
     header = Header(f)

--- a/src/write.jl
+++ b/src/write.jl
@@ -30,6 +30,11 @@ function makeresiduals(f::C3DFile{END}, m::String) where {END}
     return r
 end
 
+function unsafe_nonmissing(x)
+    real_eltype = nonmissingtype(eltype(x))
+    return unsafe_wrap(Array{real_eltype,ndims(x)}, Ptr{real_eltype}(pointer(x)), size(x))
+end
+
 function writedata(io::IO, f::C3DFile{END}) where {END<:AbstractEndian}
     h = Header(f)
     POINT_SCALE = f.groups[:POINT][Float32, :SCALE]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,5 +2,7 @@
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/blanklabels.jl
+++ b/test/blanklabels.jl
@@ -1,6 +1,7 @@
 @testset "empty LABELS" begin
     @test_nothrow readc3d(artifact"sample24/MotionMonitorC3D.c3d")
     f = readc3d(artifact"sample24/MotionMonitorC3D.c3d")
+    @test_internalconsistency f
     @test !any(isempty.(collect(keys(f.point))))
     @test !any(isempty.(collect(keys(f.analog))))
 end

--- a/test/identical.jl
+++ b/test/identical.jl
@@ -29,14 +29,37 @@
         end
     end
 
-    @testset "sample01 files" begin
-        comparefiles.(Ref(joinpath(artifact"sample01", sample01[1])), joinpath.(Ref(artifact"sample01"), sample01[2:end]))
+    @testset "sample01" begin
+        reference = joinpath(artifact"sample01", sample01[1])
+        @testset "$(basename(reference)) vs. $(basename(candidate))" for candidate in sample01[2:end]
+            comparefiles(reference, joinpath(artifact"sample01", candidate))
+        end
     end
     @testset "sample02 files" begin
-        comparefiles.(Ref(joinpath(artifact"sample02", sample02[1])), joinpath.(Ref(artifact"sample02"), sample02[2:end]))
+        reference = joinpath(artifact"sample02", sample02[1])
+        @testset "$(basename(reference)) vs. $(basename(candidate))" for candidate in sample02[2:end]
+            if candidate == "dec_int.c3d"
+                # the dec_int.c3d file has a smattering of incorrect camera values for the
+                # listed points (ie confirmed by looking at the binary, differs from the
+                # other 5)
+                # Example using "LFT2", the first sample is 0x1930-0x193F in pc_real.c3d and
+                # 0x1898-0x189F in dec_int.c3d. The residual is stored at 0x193C and 0x189E
+                # and is 0x46642400 and 0x3a09, respectively.
+                # `(UInt16(reinterpret(Float32, 0x46642400)) == 0x3909) != 0x3a09`
+                comparefiles(reference, joinpath(artifact"sample02", candidate);
+                    ignore_cameras=["RFT2", "RSK1", "RSK2", "RSK3", "RTH1", "RTH3", "RPV2",
+                        "LSK1", "LSK2", "LFT1", "LFT2", "RAR3", "RFA3", "LAR3", "LFA2",
+                        "LFA3"])
+            else
+                comparefiles(reference, joinpath(artifact"sample02", candidate))
+            end
+        end
     end
     @testset "sample08 files" begin
-        comparefiles.(Ref(joinpath(artifact"sample08", sample08[1])), joinpath.(Ref(artifact"sample08"), sample08[2:end]))
+        reference = joinpath(artifact"sample08", sample08[1])
+        @testset "$(basename(reference)) vs. $(basename(candidate))" for candidate in sample08[2:end]
+            comparefiles(reference, joinpath(artifact"sample08", candidate))
+        end
     end
 end
 

--- a/test/identical.jl
+++ b/test/identical.jl
@@ -19,6 +19,16 @@
                  "TESTCPI.c3d",
                  "TESTDPI.c3d" ]
 
+    @testset "sample0[128] files internal consistency" begin
+        @testset "$file" for file in vcat(
+            joinpath.(Ref(artifact"sample01"), sample01),
+            joinpath.(Ref(artifact"sample02"), sample02),
+            joinpath.(Ref(artifact"sample08"), sample08))
+
+            @test_internalconsistency readc3d(file)
+        end
+    end
+
     @testset "sample01 files" begin
         comparefiles.(Ref(joinpath(artifact"sample01", sample01[1])), joinpath.(Ref(artifact"sample01"), sample01[2:end]))
     end

--- a/test/publicinterface.jl
+++ b/test/publicinterface.jl
@@ -1,3 +1,40 @@
+const readable_files = [
+    artifact"sample15/FP1.C3D"
+    artifact"sample15/FP2.C3D"
+    artifact"sample17/128analogchannels.c3d"
+    artifact"sample19/sample19.c3d"
+    artifact"sample31/large01.c3d"
+    artifact"sample31/large02.c3d"
+    artifact"sample33/bigparlove.c3d"
+    artifact"sample01/Eb015pr.c3d"
+    artifact"sample03/gait-pig.c3d"
+    artifact"sample00/Vicon Motion Systems/TableTennis.c3d"
+    artifact"sample36/18124framesi.c3d"
+    artifact"sample36/18124framesf.c3d"
+    artifact"sample36/36220framesi.c3d"
+    artifact"sample36/36220framesf.c3d"
+    artifact"sample36/72610framesi.c3d"
+    artifact"sample36/72610framesf.c3d"
+    artifact"sample36/18124framesi.c3d"
+    artifact"sample01/Eb015pr.c3d"
+    artifact"sample16/basketball.c3d"
+    artifact"sample16/giant.c3d"
+    artifact"sample16/golf.c3d"
+    artifact"sample29/Facial-Sing.c3d"
+    artifact"sample29/OptiTrack-IITSEC2007.c3d"
+    artifact"sample34/AlbertoINT.c3d"
+    artifact"sample34/AlbertoREAL.c3d"
+    artifact"sample34/Basketball.c3d"
+    artifact"sample35/Mega Electronics Isokinetic EMG Angle Torque Sample File.c3d"
+    artifact"sample01/Eb015pr.c3d"
+    artifact"sample03/gait-pig.c3d"
+    artifact"sample03/gait-pig-nz.c3d"
+    artifact"sample01/Eb015pr.c3d"
+    artifact"sample18/bad_parameter_section.c3d"
+    artifact"sample27/kyowadengyo.c3d"
+    artifact"sample24/MotionMonitorC3D.c3d"
+]
+
 @testset "readc3d kwargs, etc" begin
     @test_nothrow readc3d(artifact"sample01/Eb015pr.c3d"; paramsonly=true)
     @test_nothrow readc3d(artifact"sample01/Eb015pr.c3d"; paramsonly=true, validate=false)
@@ -22,73 +59,10 @@
     @test show(devnull, MIME("text/plain"), f) == nothing
 
     @testset "Show" begin
-        @test show(devnull, readc3d(artifact"sample15/FP1.C3D")) === nothing
-        @test show(devnull, readc3d(artifact"sample15/FP2.C3D")) === nothing
-        @test show(devnull, readc3d(artifact"sample17/128analogchannels.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample19/sample19.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample31/large01.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample31/large02.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample33/bigparlove.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample03/gait-pig.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample00/Vicon Motion Systems/TableTennis.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample36/18124framesi.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample36/18124framesf.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample36/36220framesi.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample36/36220framesf.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample36/72610framesi.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample36/72610framesf.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample36/18124framesi.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample16/basketball.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample16/giant.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample16/golf.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample29/Facial-Sing.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample29/OptiTrack-IITSEC2007.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample34/AlbertoINT.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample34/AlbertoREAL.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample34/Basketball.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample35/Mega Electronics Isokinetic EMG Angle Torque Sample File.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample03/gait-pig.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample03/gait-pig-nz.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample18/bad_parameter_section.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample27/kyowadengyo.c3d")) === nothing
-        @test show(devnull, readc3d(artifact"sample24/MotionMonitorC3D.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample15/FP1.C3D")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample15/FP2.C3D")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample17/128analogchannels.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample19/sample19.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample31/large01.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample31/large02.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample33/bigparlove.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample03/gait-pig.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample00/Vicon Motion Systems/TableTennis.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample36/18124framesi.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample36/18124framesf.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample36/36220framesi.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample36/36220framesf.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample36/72610framesi.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample36/72610framesf.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample36/18124framesi.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample16/basketball.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample16/giant.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample16/golf.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample29/Facial-Sing.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample29/OptiTrack-IITSEC2007.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample34/AlbertoINT.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample34/AlbertoREAL.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample34/Basketball.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample35/Mega Electronics Isokinetic EMG Angle Torque Sample File.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample03/gait-pig.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample03/gait-pig-nz.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample01/Eb015pr.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample18/bad_parameter_section.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample27/kyowadengyo.c3d")) === nothing
-        @test show(devnull, MIME"text/plain"(), readc3d(artifact"sample24/MotionMonitorC3D.c3d")) === nothing
+        @testset "$file" for file in readable_files
+            @test_internalconsistency readc3d(file)
+            @test_nothrow show(devnull, readc3d(file))
+            @test_nothrow show(devnull, MIME"text/plain"(), readc3d(file))
+        end
     end
 end

--- a/test/publicinterface.jl
+++ b/test/publicinterface.jl
@@ -4,7 +4,7 @@
     @test_nothrow readc3d(artifact"sample03/gait-pig.c3d"; strip_prefixes=true)
 
     # issue #11
-    @test_throws ArgumentError readc3d(artifact"sample00/Vicon Motion Systems/TableTennis.c3d"; strip_prefixes=true)
+    @test_throws C3D.DuplicateMarkerError readc3d(artifact"sample00/Vicon Motion Systems/TableTennis.c3d"; strip_prefixes=true)
 
     # C3D length
     @test numpointframes(readc3d(artifact"sample36/18124framesi.c3d")) == 18124

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using C3D, Test, LazyArtifacts, Artifacts, TOML
+using C3D, Test, LazyArtifacts, Artifacts, TOML, Logging, LoggingExtras
 using TOML: parsefile
 
 ## List of sample data archived from the C3D.org website on Dec 12, 2022
@@ -42,17 +42,23 @@ using TOML: parsefile
 
 include("testutils.jl")
 
-@testset verbose=true "C3D" begin
-    include("identical.jl")
-    include("publicinterface.jl")
-    include("validate.jl")
-    include("bigdata.jl")
-    include("singledata.jl")
-    include("invalid.jl")
-    include("blanklabels.jl")
-    include("badformats.jl")
-    include("inference.jl")
-    include("utils.jl")
+function duplicate_warning(logargs)
+    return !contains(logargs.message, r"^Duplicate")
+end
 
-    include("write.jl")
+@testset verbose=true "C3D" begin
+    with_logger(ActiveFilteredLogger(duplicate_warning, global_logger())) do
+        include("identical.jl")
+        include("publicinterface.jl")
+        include("validate.jl")
+        include("bigdata.jl")
+        include("singledata.jl")
+        include("invalid.jl")
+        include("blanklabels.jl")
+        include("badformats.jl")
+        include("inference.jl")
+        include("utils.jl")
+
+        include("write.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,16 +42,17 @@ using TOML: parsefile
 
 include("testutils.jl")
 
-include("identical.jl")
-include("publicinterface.jl")
-include("validate.jl")
-include("bigdata.jl")
-include("singledata.jl")
-include("invalid.jl")
-include("blanklabels.jl")
-include("badformats.jl")
-include("inference.jl")
-include("utils.jl")
+@testset verbose=true "C3D" begin
+    include("identical.jl")
+    include("publicinterface.jl")
+    include("validate.jl")
+    include("bigdata.jl")
+    include("singledata.jl")
+    include("invalid.jl")
+    include("blanklabels.jl")
+    include("badformats.jl")
+    include("inference.jl")
+    include("utils.jl")
 
-include("write.jl")
-
+    include("write.jl")
+end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -5,6 +5,15 @@ macro test_nothrow(ex)
     esc(:(@test ($(ex); true)))
 end
 
+macro test_internalconsistency(f)
+    esc(quote
+        @test length(($f).point) == ($f).groups[:POINT][Int, :USED]
+        @test length(($f).residual) == ($f).groups[:POINT][Int, :USED]
+        @test length(($f).cameras) == ($f).groups[:POINT][Int, :USED]
+        @test length(($f).analog) == ($f).groups[:ANALOG][Int, :USED]
+    end)
+end
+
 function comparefiles(reference, candidate)
     @test_nothrow readc3d(reference; missingpoints=false)
     ref = readc3d(reference; missingpoints=false)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -15,6 +15,19 @@ macro test_internalconsistency(f)
     end)
 end
 
+function readdir_recursive(dir; join=false)
+    outfiles = String[]
+    for (root, dirs, files) in walkdir(dir)
+        if join
+            append!(outfiles, joinpath.(root, files))
+        else
+            append!(outfiles, files)
+        end
+    end
+
+    return outfiles
+end
+
 function comparefiles(reference, candidate)
     @test_nothrow readc3d(reference; missingpoints=false)
     ref = readc3d(reference; missingpoints=false)

--- a/test/validate.jl
+++ b/test/validate.jl
@@ -2,9 +2,8 @@
     let
         path, _io = mktemp()
         write(_io, zeros(UInt8, 10))
-        seekstart(_io)
-        @test_throws r"not a valid C3D file" C3D._readparams(_io, :drop)
         close(_io)
+        @test_throws r"not a valid C3D file" readc3d(path)
     end
 
     using C3D: validatec3d, MissingParametersError, MissingGroupsError

--- a/test/validate.jl
+++ b/test/validate.jl
@@ -1,14 +1,14 @@
 @testset "Validation" begin
     let
-        io = IOBuffer(zeros(UInt8, 10))
         path, _io = mktemp()
+        write(_io, zeros(UInt8, 10))
+        seekstart(_io)
+        @test_throws r"not a valid C3D file" C3D._readparams(_io, :drop)
         close(_io)
-        @test_throws r"not a valid C3D file" C3D._readparams(path, io)
     end
 
     using C3D: validatec3d, MissingParametersError, MissingGroupsError
     f = readc3d(artifact"sample01/Eb015pr.c3d")
-    header, groups = f.header, f.groups
 
     @test_nothrow readc3d(artifact"sample28/dynamic.C3D")
     @test_nothrow readc3d(artifact"sample28/standing.C3D")

--- a/test/write.jl
+++ b/test/write.jl
@@ -14,67 +14,73 @@ function compare_header_write(fn)
 end
 
 @testset "Writing" begin
+    artifacts = keys(parsefile(find_artifacts_toml(@__FILE__)))
     # Test that headers can read/write round-trip identically
     @testset "Headers" begin
-        for art in keys(parsefile(find_artifacts_toml(@__FILE__)))
-            @testset "Artifact: $art" begin
-                for fn in filter(contains(r".c3d$"), readdir(@artifact_str(art); join=true))
-                    # Those files are incomplete (end is cut off)
-                    art == "sample13" && basename(fn) in ("Dance.c3d", "golfswing.c3d") &&
-                        continue
-                    ref, comp = compare_header_write(fn)
-                    @test ref == comp
-                end
-            end
-        end
+    @testset "artifact\"$art\"" for art in artifacts
+        allfiles = filter(contains(r".c3d$"i), readdir_recursive(@artifact_str(art); join=true))
+    @testset "File \"$(replace(fn, @artifact_str(art)*'/' => ""))\"" for fn in allfiles
+        # Those files are incomplete (end is cut off)
+        art == "sample13" && basename(fn) in ("Dance.c3d", "golfswing.c3d") &&
+            continue
+
+        ref, comp = compare_header_write(fn)
+        @test ref == comp
+    end
+    end
     end
 
     # Test that groups can read/write round-trip identically
     @testset "Groups" begin
-        for fn in filter(contains(r".c3d$"), readdir(artifact"sample08"; join=true))
-            f = readc3d(fn)
-            gs = keys(f.groups)
+    @testset "artifact\"$art\"" for art in artifacts
+        allfiles = filter(contains(r".c3d$"i), readdir_recursive(@artifact_str(art); join=true))
+    @testset "File \"$(replace(fn, @artifact_str(art)*'/' => ""))\"" for fn in allfiles
+        f = readc3d(fn)
+        gs = keys(f.groups)
 
-            for g in gs
-                @test write(IOBuffer(), f.groups[g]) == writesize(f.groups[g])
-                @test ==(compare_parameters(f, g))
-            end
+        for g in gs
+            @test write(IOBuffer(), f.groups[g]) == writesize(f.groups[g])
+            @test ==(compare_parameters(f, g))
         end
+    end
+    end
     end
 
     # Test that parameters can read/write round-trip identically (trimmed white-space is
     # ignored)
-    @testset "Parameters" begin
-        for fn in filter(contains(r".c3d$"), readdir(artifact"sample08"; join=true))
-            f = readc3d(fn)
-            fio = open(fn)
-            gs = keys(f.groups)
-            ps = [ (g,p) for g in gs for p in keys(f.groups[g].params) ]
+    @testset "Parameters:" begin
+    @testset "artifact\"$art\"" for art in artifacts
+        allfiles = filter(contains(r".c3d$"i), readdir_recursive(@artifact_str(art); join=true))
+    @testset "File \"$(replace(fn, @artifact_str(art)*'/' => ""))\"" for fn in allfiles
+        f = readc3d(fn)
+        fio = open(fn)
+        gs = keys(f.groups)
+        ps = [ (g,p) for g in gs for p in keys(f.groups[g].params) ]
 
-            for (g,p) in ps
-                @test write(IOBuffer(), f.groups[g].params[p], endianness(f)) == writesize(f.groups[g].params[p])
-                expr = :(==(compare_parameters($f, :GROUP, :PARAMETER)))
-                expr.args[2].args[3] = QuoteNode(g) # replace :GROUP with g
-                expr.args[2].args[4] = QuoteNode(p)
+        for (g,p) in ps
+            @test write(IOBuffer(), f.groups[g].params[p], endianness(f)) == writesize(f.groups[g].params[p])
 
-                # eval so that the group and parameter symbols appear as literals for
-                    # readability if the test fails
-                @eval @test $expr
-            end
+            # :GROUP and :PARAMETER are placeholders that are replaced with the actual
+            # group and parameter names
+            expr = :(==(compare_parameters($f, :GROUP, :PARAMETER)))
+            expr.args[2].args[3] = QuoteNode(g) # replace :GROUP with g
+            expr.args[2].args[4] = QuoteNode(p) # same for :PARAMETER
+
+            # eval so that the group and parameter symbols appear as literals for
+                # readability if the test fails
+            @eval @test $expr
         end
     end
+    end
+    end
 
-    @testset "Files" begin
-        for art in ["sample01"]#, "sample02", "sample08"]
-            @testset "Artifact: $art" begin
-                for fn in filter(contains(r".c3d$"), readdir(@artifact_str(art); join=true))
-                    p, io = mktemp()
-                    writec3d(io, readc3d(fn))
-                    flush(io)
-                    close(io)
-                    comparefiles(fn, p)
-                end
-            end
+    @testset "Whole file: artifact\"$art\"" for art in ["sample01"]#, "sample02", "sample08"]
+        @testset failfast=true "File \"$(replace(fn, @artifact_str(art)*'/' => ""))\"" for fn in filter(contains(r".c3d$"i), readdir_recursive(@artifact_str(art); join=true))
+            p, io = mktemp()
+            writec3d(io, readc3d(fn))
+            flush(io)
+            close(io)
+            comparefiles(fn, p)
         end
     end
 end

--- a/test/write.jl
+++ b/test/write.jl
@@ -1,18 +1,5 @@
 using C3D: _elsize, _ndims, _size, writesize
 
-function compare_header_write(fn)
-    ref = open(fn) do io
-        read(io, 512)
-    end;
-    f = readc3d(fn; paramsonly=true)
-
-    io = IOBuffer()
-    write(io, f.header);
-    comp = take!(io);
-
-    return ref, comp
-end
-
 @testset "Writing" begin
     artifacts = keys(parsefile(find_artifacts_toml(@__FILE__)))
     # Test that headers can read/write round-trip identically
@@ -24,7 +11,7 @@ end
         art == "sample13" && basename(fn) in ("Dance.c3d", "golfswing.c3d") &&
             continue
 
-        ref, comp = compare_header_write(fn)
+        ref, comp = compareheader(fn)
         @test ref == comp
     end
     end

--- a/test/write.jl
+++ b/test/write.jl
@@ -35,7 +35,7 @@ end
     @testset "artifact\"$art\"" for art in artifacts
         allfiles = filter(contains(r".c3d$"i), readdir_recursive(@artifact_str(art); join=true))
     @testset "File \"$(replace(fn, @artifact_str(art)*'/' => ""))\"" for fn in allfiles
-        f = readc3d(fn)
+        f = readc3d(fn; paramsonly=true)
         gs = keys(f.groups)
 
         for g in gs
@@ -52,7 +52,7 @@ end
     @testset "artifact\"$art\"" for art in artifacts
         allfiles = filter(contains(r".c3d$"i), readdir_recursive(@artifact_str(art); join=true))
     @testset "File \"$(replace(fn, @artifact_str(art)*'/' => ""))\"" for fn in allfiles
-        f = readc3d(fn)
+        f = readc3d(fn; paramsonly=true)
         fio = open(fn)
         gs = keys(f.groups)
         ps = [ (g,p) for g in gs for p in keys(f.groups[g].params) ]

--- a/test/write.jl
+++ b/test/write.jl
@@ -66,22 +66,68 @@ using C3D: _elsize, _ndims, _size, writesize
         allfiles = filter(contains(r".c3d$"i), readdir_recursive(@artifact_str(art); join=true))
     @testset "File \"$(replace(fn, @artifact_str(art)*'/' => ""))\"" for fn in allfiles
         # these 2 artifact"sample30" files have incorrectly formated residuals that we don't
-        # intend to replicate/match
+        # intend to replicate/match (we fail to read because of the incorrect residuals)
         fn == artifact"sample30/admarche2.c3d" && continue
         fn == artifact"sample30/marche281.c3d" && continue
+
+        # this is an out-of-spec file where the ANALOG:RATE is not an integer multiple of the
+        # POINT:RATE. We will read this, but we will not support writing this
+        fn == artifact"sample11/evart.c3d" && continue
+
+        failanalog=false
+
+        # non-integer samples in original file that are correctly(?) rounded to integers on write
+        # Absolute difference of [2.6020852f-17, 5.2041704f-17], 2 samples
+        fn == artifact"sample00/Innovative Sports Training/Static Pose.c3d" && (failanalog=true;)
+        # Absolute difference of 8.673617f-18, 2 samples
+        fn == artifact"sample00/Innovative Sports Training/Gait with EMG.c3d" && (failanalog=true;)
 
         ref, comp = comparedata(fn)
         refdata, (refpoint, refresidual, refanalog) = ref
         compdata, (comppoint, compresidual, companalog) = comp
 
-        passpoint = @test refpoint == comppoint
-        passresidual = @test refresidual == compresidual
-        passanalog = @test refanalog == companalog
-        fails = any(p -> p isa Test.Fail, (passpoint, passresidual, passanalog))
+        nan_equal(x,y) = (isnan(x) && isnan(y)) || x == y
+        passpoint = @test mapreduce(nan_equal, &, refpoint, comppoint)
+        passresidual = @test mapreduce(nan_equal, &, refresidual, compresidual)
+        passanalog = @test mapreduce(nan_equal, &, refanalog, companalog) broken=failanalog
+        fails = any(p -> !(p isa Test.Pass), (passpoint, passresidual, passanalog))
 
-        nb = length(compdata)
-        if checkindex(Bool, eachindex(refdata), nb)
-            @test @view(refdata[begin:nb]) == compdata broken=fails
+        # artifact"sample27/kyowadengyo.c3d" contains analog contentful(?) channels scaled by
+        # zero; leading to differences betwee original and written data; although the
+        # read/processed data in the analog channels remains the same (±0)
+        fn == artifact"sample27/kyowadengyo.c3d" && (fails=true;)
+
+        # residuals are (incorrectly) stored as unsigned int's but (correctly) written as signed ints
+        fn == artifact"sample05/vicon512.c3d" && (fails=true;)
+        fn == artifact"sample03/gait-pig-nz.c3d" && (fails=true;)
+        fn == artifact"sample12/c24089 13.c3d" && (fails=true;) # slow read; add to benchmarks and/or profile
+        fn == artifact"sample07/16bitanalog.c3d" && (fails=true;)
+        fn == artifact"sample23/Vicon_analysis.c3d" && (fails=true;)
+        # the following also have (one-time) floating-point non-cummutativity in the analog data
+        fn == artifact"sample17/128analogchannels.c3d" && (fails=true;)
+        fn == artifact"sample26/Capture0002.c3d" && (fails=true;)
+        fn == artifact"sample26/Capture0003.c3d" && (fails=true;)
+        fn == artifact"sample26/Capture0004.c3d" && (fails=true;)
+        fn == artifact"sample26/Capture0008_Standing.c3d" && (fails=true;)
+        fn == artifact"sample26/Standing_Hybrid_2.c3d" && (fails=true;)
+        fn == artifact"sample26/Walking_Hybrid_1_1.c3d" && (fails=true;)
+        fn == artifact"sample26/Walking_Hybrid_1_2.c3d" && (fails=true;)
+        fn == artifact"sample26/Walking_Hybrid_1_3.c3d" && (fails=true;)
+        fn == artifact"sample26/Walking_Hybrid_1_4.c3d" && (fails=true;)
+        fn == artifact"sample26/Walking_Hybrid_1_5.c3d" && (fails=true;)
+        fn == artifact"sample26/Walking_Hybrid_2.c3d" && (fails=true;)
+
+        # floating-point non-commutativity in analog data; these changes are one-time (ie if
+        # read then write the same file sequentially, all files after the first will be exactly
+        # identical)
+        # 52.0f0 * -0.05f0 / -0.05f0 != 52.0f0
+        fn == artifact"sample00/Codamotion/codamotion_gaitwands_19970212.c3d" && (fails=true;)
+        # (-27.32653f0 * (1.0f0 * 0.0048828125f0) / (1.0f0 * 0.0048828125f0) + -0.0f0 != -27.32653f0
+        fn == artifact"sample24/MotionMonitorC3D.c3d" && (fails=true;)
+
+        # Compare raw binary data from original and written files
+        if checkindex(Bool, eachindex(refdata), length(compdata))
+            @test @view(refdata[begin:length(compdata)]) == compdata broken=fails
         elseif checkindex(Bool, eachindex(compdata), length(refdata))
             @test refdata == @view(compdata[begin:length(refdata)]) broken=fails
         end


### PR DESCRIPTION
Previously, the `validate` function modified groups and parameters to be consistent/correct for creating the Julia C3DFile object. This is problematic where certain Julia requirements are stricter than the C3D file spec (e.g. labels need not be unique, but Dict keys must be) and the validation resulted in loss of the as-read data.

This PR generally cleans things up and reduces differences between the original .c3d and the .c3d written by C3D.jl.